### PR TITLE
Fix release CI: add Poetry to PATH on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Add Poetry to PATH
+        shell: pwsh
+        run: echo "$env:USERPROFILE\.local\bin" >> $env:GITHUB_PATH
+
       - name: Install dependencies
         run: poetry install --with dev
 


### PR DESCRIPTION
## Summary

- Same fix as #1 but for `release.yml` — `snok/install-poetry` installs to `~\.local\bin` which isn't on `PATH` for subsequent steps on Windows

## Test plan

- [ ] Release workflow runs successfully on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)