### PR TITLE
⚙️ Fix release CI: add Poetry to PATH on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Add Poetry to PATH
+        shell: pwsh
+        run: echo "$env:USERPROFILE\.local\bin" >> $env:GITHUB_PATH
+
       - name: Install dependencies
         run: poetry install --with dev
 


### PR DESCRIPTION
Same fix as test.yml — snok/install-poetry uses ~/.local/bin which is not on PATH for subsequent steps.