### PR TITLE
🎇 Add installer releases and in-app GitHub auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,35 @@ jobs:
       - name: Install dependencies
         run: poetry install --with dev
 
+      - name: Set release version
+        shell: pwsh
+        run: |
+          $tag = if ("${{ inputs.deploy_version }}" -ne "") { "${{ inputs.deploy_version }}" } else { "${{ github.ref_name }}" }
+          $version = $tag.TrimStart('v')
+          $content = Get-Content version.py -Raw
+          $content = $content -replace '__version__ = ".*"', "__version__ = `"$version`""
+          Set-Content version.py $content
+          echo "APP_VERSION=$version" >> $env:GITHUB_ENV
+          echo "RELEASE_TAG=$tag" >> $env:GITHUB_ENV
+
       - name: Build with PyInstaller
         run: poetry run pyinstaller euterpium.spec
 
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Build installer
+        shell: pwsh
+        run: |
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "/DAppVersion=$env:APP_VERSION" "/DReleaseTag=$env:RELEASE_TAG" euterpium.iss
+
       - name: Zip the build
         run: |
-          $tag = if ("${{ inputs.deploy_version }}" -ne "") { "${{ inputs.deploy_version }}" } else { "${{ github.ref_name }}" }
+          $tag = $env:RELEASE_TAG
           $zip = "euterpium-${tag}-windows.zip"
           Compress-Archive -Path dist\euterpium\* -DestinationPath $zip
           echo "ZIP_NAME=$zip" >> $env:GITHUB_ENV
-          echo "RELEASE_TAG=$tag" >> $env:GITHUB_ENV
+          echo "INSTALLER_NAME=dist\installer\euterpium-${tag}-setup.exe" >> $env:GITHUB_ENV
         shell: pwsh
 
       - name: Create release
@@ -63,6 +82,8 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           name: "Euterpium ${{ env.RELEASE_TAG }}"
           generate_release_notes: true
-          files: ${{ env.ZIP_NAME }}
+          files: |
+            ${{ env.ZIP_NAME }}
+            ${{ env.INSTALLER_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ On first launch, the settings window opens automatically. Enter your ACRCloud cr
 
 Config is stored at `%LOCALAPPDATA%\euterpium\euterpium.ini`.
 
+## Installer and updates
+
+- Release builds now target a Windows installer built from PyInstaller output.
+- GitHub Releases should publish both a portable zip and an installer `.exe`.
+- The app can check GitHub Releases for a newer installer and offer it from the tray menu.
+
 ## Architecture
 
 | File | Purpose |

--- a/euterpium.iss
+++ b/euterpium.iss
@@ -1,0 +1,43 @@
+#define MyAppName "Euterpium"
+#ifndef AppVersion
+  #define AppVersion "0.1.0"
+#endif
+#ifndef ReleaseTag
+  #define ReleaseTag "v" + AppVersion
+#endif
+
+[Setup]
+AppId={{B2C48E1C-6E56-4FE9-B1EF-47A643FE53D4}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher=aquarion
+DefaultDirName={localappdata}\Programs\Euterpium
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir=dist\installer
+OutputBaseFilename=euterpium-{#ReleaseTag}-setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64compatible
+CloseApplications=yes
+RestartApplications=no
+UninstallDisplayIcon={app}\euterpium.exe
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "dist\euterpium\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\euterpium.exe"
+Name: "{group}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\euterpium.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\euterpium.exe"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent

--- a/euterpium.spec
+++ b/euterpium.spec
@@ -15,6 +15,7 @@ a = Analysis(
         # Bundle the default config and icon as data files
         ('euterpium.ini', '.'),
         ('icons/app_icon.png', '.'),
+        ('icons/app_listening.png', '.'),
     ],
     hiddenimports=[
         # tkinter and its sub-modules are sometimes missed

--- a/main.py
+++ b/main.py
@@ -8,9 +8,11 @@ import threading
 import config
 import smtc
 from tracker import Tracker
-from ui.notifications import notify_track
+from ui.notifications import notify_track, notify_update_available
 from ui.tray import TrayIcon
 from ui.window import MainWindow
+from updater import UpdateManager
+from version import __version__
 
 # Configure logging before any local imports so module-level log messages
 # (e.g. winsdk availability) are captured from the start
@@ -24,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 def main():
+    logger.info("Starting Euterpium %s", __version__)
+
     # Report winsdk status now that logging is definitely active
     if smtc.WINSDK_AVAILABLE:
         logger.info("SMTC: winsdk loaded — media session detection enabled")
@@ -46,6 +50,12 @@ def main():
         # Trigger manual fingerprinting
         tracker.force_fingerprint()
 
+    def on_check_for_updates():
+        update_manager.check_for_updates(manual=True)
+
+    def on_install_update():
+        update_manager.install_available_update()
+
     window = MainWindow(
         on_quit=on_quit, on_show_settings=on_show_settings, on_fingerprint_now=on_fingerprint_now
     )
@@ -53,8 +63,12 @@ def main():
         on_show_window=lambda: window.show(),
         on_show_settings=on_show_settings,
         on_quit=on_quit,
+        on_check_for_updates=on_check_for_updates,
+        on_install_update=on_install_update,
+        current_version=__version__,
     )
     tracker = Tracker(event_queue=event_queue)
+    update_manager = UpdateManager(event_queue=event_queue, current_version=__version__)
 
     # ── Event pump: moves tracker events → window + tray ─────────────────
 
@@ -89,6 +103,22 @@ def main():
                 window.log_status(message, level="error")
                 logger.error(message)
 
+            elif kind == "update_available":
+                _, update = msg
+                tray.set_available_update(update)
+                window.log_status(f"Update available: Euterpium {update.version}", level="info")
+                logger.info("Update available: Euterpium %s", update.version)
+                notify_update_available(update.version)
+
+            elif kind == "update_installer_launched":
+                _, update, installer_path = msg
+                window.log_status(
+                    f"Installer launched for Euterpium {update.version}; closing app...",
+                    level="info",
+                )
+                logger.info("Installer launched from %s", installer_path)
+                on_quit()
+
     # ── Start threads ─────────────────────────────────────────────────────
 
     # Event pump thread
@@ -117,6 +147,7 @@ def main():
 
     # Tray runs in main thread (required by pystray on Windows) — blocks here
     logger.info("Euterpium running — check your system tray")
+    update_manager.check_for_updates(manual=False)
     tray.run()
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+import pytest
+
+import updater
+
+
+def test_normalize_version_accepts_tag_prefix():
+    assert updater.normalize_version("v1.2.3") == (1, 2, 3)
+
+
+def test_is_newer_version_detects_update():
+    assert updater.is_newer_version("0.1.0", "v0.2.0") is True
+
+
+def test_is_newer_version_ignores_same_release():
+    assert updater.is_newer_version("0.2.0", "v0.2.0") is False
+
+
+def test_find_installer_asset_prefers_setup_exe():
+    asset = updater.find_installer_asset(
+        [
+            {"name": "euterpium-v0.2.0-windows.zip"},
+            {"name": "euterpium-v0.2.0-setup.exe", "browser_download_url": "https://a"},
+            {"name": "euterpium-v0.2.0.exe", "browser_download_url": "https://b"},
+        ]
+    )
+
+    assert asset["name"] == "euterpium-v0.2.0-setup.exe"
+
+
+def test_parse_latest_release_returns_none_when_not_newer():
+    release = {"tag_name": "v0.1.0", "assets": []}
+    assert updater.parse_latest_release(release, "0.1.0") is None
+
+
+def test_parse_latest_release_raises_without_installer():
+    release = {"tag_name": "v0.2.0", "assets": [{"name": "euterpium-v0.2.0.zip"}]}
+
+    with pytest.raises(updater.UpdateError):
+        updater.parse_latest_release(release, "0.1.0")
+
+
+def test_parse_latest_release_returns_available_update():
+    release = {
+        "tag_name": "v0.2.0",
+        "html_url": "https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        "assets": [
+            {
+                "name": "euterpium-v0.2.0-setup.exe",
+                "browser_download_url": "https://github.com/download/setup.exe",
+            }
+        ],
+    }
+
+    update = updater.parse_latest_release(release, "0.1.0")
+
+    assert update is not None
+    assert update.version == "0.2.0"
+    assert update.installer_name == "euterpium-v0.2.0-setup.exe"
+
+
+def test_fetch_latest_update_uses_github_response(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "tag_name": "v0.3.0",
+                "html_url": "https://example.com/release",
+                "assets": [
+                    {
+                        "name": "euterpium-v0.3.0-setup.exe",
+                        "browser_download_url": "https://example.com/setup.exe",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(updater.requests, "get", lambda *args, **kwargs: Response())
+
+    update = updater.fetch_latest_update("0.2.0")
+
+    assert update is not None
+    assert update.version == "0.3.0"
+
+
+def test_download_installer_writes_file(monkeypatch, tmp_path):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size=0):
+            yield b"hello"
+            yield b"world"
+
+    monkeypatch.setattr(updater.requests, "get", lambda *args, **kwargs: Response())
+    update = updater.AvailableUpdate(
+        version="0.3.0",
+        release_url="https://example.com/release",
+        installer_name="euterpium-v0.3.0-setup.exe",
+        installer_url="https://example.com/setup.exe",
+    )
+
+    path = updater.download_installer(update, tmp_path)
+
+    assert path == Path(tmp_path) / "euterpium-v0.3.0-setup.exe"
+    assert path.read_bytes() == b"helloworld"
+
+
+def test_update_manager_reports_available_update(monkeypatch):
+    events = []
+    event_queue = type("Queue", (), {"put": lambda self, item: events.append(item)})()
+    manager = updater.UpdateManager(event_queue=event_queue, current_version="0.1.0")
+    expected_update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://example.com/release",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://example.com/setup.exe",
+    )
+
+    monkeypatch.setattr(updater, "fetch_latest_update", lambda current_version: expected_update)
+
+    manager._check_worker(manual=True)
+
+    assert ("update_available", expected_update) in events

--- a/ui/notifications.py
+++ b/ui/notifications.py
@@ -7,10 +7,13 @@ logger = logging.getLogger(__name__)
 
 try:
     from win11toast import notify as _notify
+
     WIN11TOAST_AVAILABLE = True
 except ImportError:
     WIN11TOAST_AVAILABLE = False
-    logger.warning("win11toast not available — notifications disabled. Install with: pip install win11toast")
+    logger.warning(
+        "win11toast not available — notifications disabled. Install with: pip install win11toast"
+    )
 
 _ICON_PATH = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "icons", "app_icon.png")
@@ -25,7 +28,7 @@ def notify_track(track: dict, game: dict | None = None):
     if not WIN11TOAST_AVAILABLE:
         return
 
-    title  = track.get("title", "")
+    title = track.get("title", "")
     artist = track.get("artist", "")
     source = track.get("source", "")
 
@@ -34,12 +37,12 @@ def notify_track(track: dict, game: dict | None = None):
         if not game:
             return
         heading = game["display_name"]
-        body    = "Playing unrecognised track"
+        body = "Playing unrecognised track"
     elif not title:
         return
     else:
         heading = title
-        body    = artist
+        body = artist
         if game:
             body = f"{artist}  ·  {game['display_name']}" if artist else game["display_name"]
 
@@ -53,3 +56,22 @@ def notify_track(track: dict, game: dict | None = None):
     except Exception as e:
         # Notifications are best-effort — never crash the main loop
         logger.debug(f"Notification failed: {e}")
+
+
+def notify_update_available(version: str):
+    """Fires a Windows toast notification for an available app update."""
+    if not WIN11TOAST_AVAILABLE:
+        return
+
+    icon = _ICON_PATH if os.path.exists(_ICON_PATH) else None
+
+    try:
+        kwargs = {
+            "title": "Euterpium update available",
+            "body": f"Version {version} is ready to install from GitHub Releases.",
+        }
+        if icon:
+            kwargs["icon"] = icon
+        _notify(**kwargs)
+    except Exception as e:
+        logger.debug(f"Update notification failed: {e}")

--- a/ui/tray.py
+++ b/ui/tray.py
@@ -2,13 +2,18 @@
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw
+
+if TYPE_CHECKING:
+    from updater import AvailableUpdate
 
 logger = logging.getLogger(__name__)
 
 try:
     import pystray
+
     PYSTRAY_AVAILABLE = True
 except ImportError:
     PYSTRAY_AVAILABLE = False
@@ -57,14 +62,26 @@ class TrayIcon:
         on_quit()         — called when user clicks Quit
     """
 
-    def __init__(self, on_show_window, on_show_settings, on_quit):
+    def __init__(
+        self,
+        on_show_window,
+        on_show_settings,
+        on_quit,
+        on_check_for_updates=None,
+        on_install_update=None,
+        current_version: str = "",
+    ):
         self.on_show_window = on_show_window
         self.on_show_settings = on_show_settings
         self.on_quit = on_quit
+        self.on_check_for_updates = on_check_for_updates
+        self.on_install_update = on_install_update
         self._icon: pystray.Icon | None = None
         self._current_track_label = "Nothing playing"
         self._icon_default: Image.Image | None = None
         self._icon_listening: Image.Image | None = None
+        self._current_version = current_version
+        self._available_update: AvailableUpdate | None = None
 
     def update_track(self, title: str, artist: str, game_name: str | None = None):
         """Updates the tray tooltip with the current track."""
@@ -88,15 +105,47 @@ class TrayIcon:
         if self._icon:
             self._icon.menu = self._build_menu()
 
+    def set_available_update(self, update: "AvailableUpdate | None"):
+        self._available_update = update
+        self._update_menu()
+
     def _build_menu(self) -> "pystray.Menu":
-        return pystray.Menu(
+        items = [
             pystray.MenuItem(self._current_track_label, None, enabled=False),
-            pystray.Menu.SEPARATOR,
-            pystray.MenuItem("Show window",  lambda: self.on_show_window()),
-            pystray.MenuItem("Settings",     lambda: self.on_show_settings()),
-            pystray.Menu.SEPARATOR,
-            pystray.MenuItem("Quit", lambda: self._quit()),
+        ]
+
+        if self._current_version:
+            items.extend(
+                [
+                    pystray.MenuItem(f"Version {self._current_version}", None, enabled=False),
+                ]
+            )
+
+        if self._available_update is not None:
+            items.extend(
+                [
+                    pystray.MenuItem(
+                        f"Install update {self._available_update.version}",
+                        lambda: self.on_install_update() if self.on_install_update else None,
+                    ),
+                ]
+            )
+
+        items.extend(
+            [
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Show window", lambda: self.on_show_window()),
+                pystray.MenuItem("Settings", lambda: self.on_show_settings()),
+                pystray.MenuItem(
+                    "Check for updates",
+                    lambda: self.on_check_for_updates() if self.on_check_for_updates else None,
+                ),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Quit", lambda: self._quit()),
+            ]
         )
+
+        return pystray.Menu(*items)
 
     def _quit(self):
         if self._icon:
@@ -118,6 +167,7 @@ class TrayIcon:
             logger.warning("pystray unavailable — running without tray icon")
             # Keep main thread alive without tray
             import time
+
             while True:
                 time.sleep(1)
             return

--- a/updater.py
+++ b/updater.py
@@ -1,0 +1,219 @@
+"""GitHub Releases-based update checks and installer downloads."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import re
+import subprocess
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+GITHUB_OWNER = "aquarion"
+GITHUB_REPO = "euterpium"
+LATEST_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest"
+REQUEST_TIMEOUT = (5, 30)
+
+
+class UpdateError(RuntimeError):
+    """Raised when update checking or download fails."""
+
+
+@dataclass(frozen=True)
+class AvailableUpdate:
+    version: str
+    release_url: str
+    installer_name: str
+    installer_url: str
+
+
+def normalize_version(version: str) -> tuple[int, int, int]:
+    """Convert a tag or version string into a comparable 3-part tuple."""
+    parts = re.findall(r"\d+", version)
+    if not parts:
+        raise ValueError(f"Unsupported version string: {version!r}")
+
+    numbers = [int(part) for part in parts[:3]]
+    while len(numbers) < 3:
+        numbers.append(0)
+
+    return tuple(numbers)
+
+
+def is_newer_version(current_version: str, candidate_version: str) -> bool:
+    """True when the candidate version is newer than the current version."""
+    return normalize_version(candidate_version) > normalize_version(current_version)
+
+
+def find_installer_asset(assets: list[dict]) -> dict | None:
+    """Choose the preferred Windows installer asset from a GitHub release."""
+    executables = [asset for asset in assets if asset.get("name", "").lower().endswith(".exe")]
+    if not executables:
+        return None
+
+    preferred = [
+        asset
+        for asset in executables
+        if any(keyword in asset.get("name", "").lower() for keyword in ("setup", "installer"))
+    ]
+
+    return (preferred or executables)[0]
+
+
+def parse_latest_release(release: dict, current_version: str) -> AvailableUpdate | None:
+    """Convert GitHub release JSON into an installable update, if newer."""
+    if release.get("draft"):
+        return None
+
+    tag_name = release.get("tag_name")
+    if not tag_name or not is_newer_version(current_version, tag_name):
+        return None
+
+    asset = find_installer_asset(release.get("assets", []))
+    if not asset:
+        raise UpdateError("Latest release does not contain a Windows installer")
+
+    download_url = asset.get("browser_download_url")
+    name = asset.get("name")
+    if not download_url or not name:
+        raise UpdateError("Latest release installer asset is missing download metadata")
+
+    return AvailableUpdate(
+        version=tag_name.lstrip("v"),
+        release_url=release.get("html_url", ""),
+        installer_name=name,
+        installer_url=download_url,
+    )
+
+
+def fetch_latest_update(current_version: str) -> AvailableUpdate | None:
+    """Query GitHub Releases and return the newest available installer update."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"{GITHUB_REPO}-updater",
+    }
+
+    try:
+        response = requests.get(LATEST_RELEASE_URL, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        payload = response.json()
+    except requests.RequestException as exc:
+        raise UpdateError(f"Unable to reach GitHub Releases: {exc}") from exc
+    except ValueError as exc:
+        raise UpdateError("GitHub Releases returned invalid JSON") from exc
+
+    return parse_latest_release(payload, current_version)
+
+
+def download_installer(update: AvailableUpdate, destination_dir: str | Path | None = None) -> Path:
+    """Download the installer for the given update and return the local file path."""
+    target_dir = Path(destination_dir or tempfile.mkdtemp(prefix="euterpium-update-"))
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / update.installer_name
+
+    try:
+        response = requests.get(update.installer_url, stream=True, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        with target_path.open("wb") as handle:
+            for chunk in response.iter_content(chunk_size=1024 * 64):
+                if chunk:
+                    handle.write(chunk)
+    except requests.RequestException as exc:
+        raise UpdateError(f"Failed to download installer: {exc}") from exc
+    except OSError as exc:
+        raise UpdateError(f"Failed to save installer: {exc}") from exc
+
+    return target_path
+
+
+def launch_installer(installer_path: str | Path) -> None:
+    """Launch the downloaded installer without blocking the main application."""
+    path = Path(installer_path)
+    try:
+        subprocess.Popen([str(path)], close_fds=True)
+    except OSError as exc:
+        raise UpdateError(f"Failed to launch installer: {exc}") from exc
+
+
+class UpdateManager:
+    """Coordinate background update checks and installer launches."""
+
+    def __init__(self, event_queue: queue.Queue, current_version: str):
+        self.event_queue = event_queue
+        self.current_version = current_version
+        self._lock = threading.Lock()
+        self._available_update: AvailableUpdate | None = None
+        self._check_in_progress = False
+        self._install_in_progress = False
+
+    def _emit(self, event_type: str, *args) -> None:
+        self.event_queue.put((event_type, *args))
+
+    def get_available_update(self) -> AvailableUpdate | None:
+        with self._lock:
+            return self._available_update
+
+    def check_for_updates(self, manual: bool = False) -> None:
+        with self._lock:
+            if self._check_in_progress:
+                if manual:
+                    self._emit("status", "Update check already in progress")
+                return
+            self._check_in_progress = True
+
+        threading.Thread(target=self._check_worker, args=(manual,), daemon=True).start()
+
+    def _check_worker(self, manual: bool) -> None:
+        try:
+            if manual:
+                self._emit("status", "Checking for updates...")
+
+            update = fetch_latest_update(self.current_version)
+            with self._lock:
+                self._available_update = update
+
+            if update:
+                self._emit("update_available", update)
+            elif manual:
+                self._emit("status", f"Euterpium {self.current_version} is up to date")
+        except UpdateError as exc:
+            logger.warning("Update check failed: %s", exc)
+            if manual:
+                self._emit("error", f"Update check failed: {exc}")
+        finally:
+            with self._lock:
+                self._check_in_progress = False
+
+    def install_available_update(self) -> None:
+        with self._lock:
+            if self._install_in_progress:
+                self._emit("status", "Update installation already in progress")
+                return
+
+            update = self._available_update
+            if update is None:
+                self._emit("status", "No update available")
+                return
+
+            self._install_in_progress = True
+
+        threading.Thread(target=self._install_worker, args=(update,), daemon=True).start()
+
+    def _install_worker(self, update: AvailableUpdate) -> None:
+        try:
+            self._emit("status", f"Downloading Euterpium {update.version} installer...")
+            installer_path = download_installer(update)
+            launch_installer(installer_path)
+            self._emit("update_installer_launched", update, str(installer_path))
+        except UpdateError as exc:
+            logger.warning("Update install failed: %s", exc)
+            self._emit("error", f"Update install failed: {exc}")
+        finally:
+            with self._lock:
+                self._install_in_progress = False

--- a/version.py
+++ b/version.py
@@ -1,0 +1,3 @@
+"""Runtime application version information."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- add runtime version module and GitHub Releases updater service
- add background update check + tray actions for check/install update
- add Windows toast notification when a new update is available
- add Inno Setup installer script and include installer build in release workflow
- keep zip artifact while publishing installer executable
- add updater unit tests and document installer/update behavior in README

## Validation
- poetry run ruff check .
- poetry run pytest -q