### PR TITLE
Update Playnite model to event-based

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: dotnet-format
+        name: dotnet format
+        entry: dotnet format playnite-plugin/EuterpiumExporter.csproj --verify-no-changes
+        language: system
+        files: ^playnite-plugin/.*\.(cs|csproj)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If an API key is set in the active profile, requests include an `Authorization: 
 
 ## Playnite integration
 
-Euterpium includes a Playnite generic plugin that automatically exports your game library so `game_detector.py` can identify running games without any manual `[games]` configuration.
+Euterpium includes a Playnite generic plugin that automatically tells Euterpium when a game starts and stops. When a game is launched via Playnite, the plugin writes a small JSON file; Euterpium picks it up on the next poll cycle and switches to game audio fingerprinting mode. Works for Steam, GOG, Epic, emulators — any source Playnite can launch.
 
 See [docs/playnite-plugin.md](docs/playnite-plugin.md) for build, install, and auto-update instructions.
 

--- a/config.py
+++ b/config.py
@@ -222,12 +222,12 @@ def get_known_games() -> dict[str, str]:
     return dict(cfg.items("games"))
 
 
-def get_playnite_games_path() -> str:
-    """Returns the path to the Playnite-exported games JSON file."""
-    raw = _cfg().get("playnite", "games_file", fallback="").strip()
+def get_playnite_current_game_path() -> str:
+    """Returns the path to the file the Playnite plugin writes when a game is running."""
+    raw = _cfg().get("playnite", "current_game_file", fallback="").strip()
     if raw:
         return raw
-    return os.path.join(os.environ.get("APPDATA", ""), "Playnite", "euterpium_games.json")
+    return os.path.join(os.environ.get("APPDATA", ""), "Playnite", "euterpium_current_game.json")
 
 
 # ── SMTC ──────────────────────────────────────────────────────────────────────

--- a/config.py
+++ b/config.py
@@ -97,6 +97,19 @@ def _getfloat(cfg: configparser.ConfigParser, section: str, key: str, fallback: 
         return fallback
 
 
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+
+def get_log_level() -> int:
+    """Returns the configured logging level (default: INFO)."""
+    raw = _cfg().get("logging", "level", fallback="INFO").strip().upper()
+    level = getattr(logging, raw, None)
+    if not isinstance(level, int):
+        logger.warning("Invalid log level %r in config — using INFO", raw)
+        return logging.INFO
+    return level
+
+
 # ── Configured checks ────────────────────────────────────────────────────────
 
 _PLACEHOLDER_URLS = {"", "https://your-api.com/now-playing"}

--- a/docs/playnite-plugin.md
+++ b/docs/playnite-plugin.md
@@ -1,18 +1,25 @@
 # Euterpium Exporter — Playnite Plugin
 
-A Playnite generic plugin that automatically exports your game library to a JSON file so Euterpium can detect running games without manual configuration.
+A Playnite generic plugin that tells Euterpium when a game starts and stops,
+so game audio fingerprinting works automatically without manual `[games]` config.
 
 ## How it works
 
-On startup (and whenever games are added, removed, or edited), the plugin writes:
+When a game is launched via Playnite, the plugin writes:
 
 ```
-%APPDATA%\Playnite\euterpium_games.json
+%APPDATA%\Playnite\euterpium_current_game.json
 ```
 
-Euterpium reads this file on each detection cycle and merges it with any manual `[games]` entries in `euterpium.ini`. Manual entries take precedence over Playnite-detected ones.
+When the game stops, the file is deleted. Euterpium reads this file on each
+detection cycle — if it exists and the process is still alive, game mode
+(WASAPI loopback + ACRCloud fingerprinting) is active.
 
-Only games with a `File`-type play action are exported — the plugin resolves `{InstallDir}` and similar variables to extract the actual `.exe` filename.
+On Playnite startup, any stale file from a previous crash is cleared.
+
+Works for all sources Playnite can launch: Steam, GOG, Epic, emulators, etc.
+Games launched *outside* Playnite are still covered by manual `[games]` entries
+in `euterpium.ini`.
 
 ## Building
 
@@ -46,9 +53,15 @@ Playnite will check this manifest and prompt you when a new version is available
 
 ## Config
 
-By default Euterpium reads the JSON from `%APPDATA%\Playnite\euterpium_games.json`. To override the path, add to `euterpium.ini`:
+By default Euterpium looks for the current game file at
+`%APPDATA%\Playnite\euterpium_current_game.json`. To override the path,
+add to `euterpium.ini`:
 
 ```ini
 [playnite]
-games_file = C:\path\to\euterpium_games.json
+current_game_file = C:\path\to\euterpium_current_game.json
 ```
+
+## Future: REST API
+
+When issue [#16](https://github.com/aquarion/euterpium/issues/16) (local REST API) is implemented, the plugin will be updated to POST to `localhost:43174/api/game/start` and `/api/game/stop` instead of writing a file. The event-driven logic stays the same.

--- a/euterpium.ini
+++ b/euterpium.ini
@@ -35,9 +35,9 @@ min_silence_before_change = 2
 ignore = chrome.exe, firefox.exe
 
 [playnite]
-; Path to the JSON file exported by the Euterpium Exporter Playnite plugin.
-; Leave blank to use the default: %APPDATA%\Playnite\euterpium_games.json
-; games_file =
+; Path to the file the Euterpium Exporter plugin writes when a game is running.
+; Leave blank to use the default: %APPDATA%\Playnite\euterpium_current_game.json
+; current_game_file =
 
 [games]
 ; Format: process_name.exe = Display Name

--- a/euterpium.ini
+++ b/euterpium.ini
@@ -1,3 +1,7 @@
+[logging]
+; Log level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+level = INFO
+
 [acrcloud]
 host        = identify-eu-west-1.acrcloud.com
 access_key  =

--- a/game_detector.py
+++ b/game_detector.py
@@ -30,8 +30,9 @@ def _get_playnite_current_game() -> dict | None:
             logger.debug("Playnite current game file has stale PID %d — ignoring", pid)
             return None
 
+        process_name = str(data["process"]).strip().lower()
         _current_game_logged_missing = False
-        return {"process": data["process"], "display_name": data["name"]}
+        return {"process": process_name, "display_name": data["name"]}
 
     except FileNotFoundError:
         if not _current_game_logged_missing:

--- a/game_detector.py
+++ b/game_detector.py
@@ -26,6 +26,8 @@ def _load_playnite_games() -> dict[str, str]:
     try:
         mtime = os.path.getmtime(path)
     except OSError:
+        if _playnite_cache is None:
+            logger.info("Playnite games file not found: %s", path)
         return {}
 
     if _playnite_cache is not None and _playnite_cache[0] == mtime:
@@ -39,11 +41,11 @@ def _load_playnite_games() -> dict[str, str]:
             for entry in data
             if "process" in entry and "name" in entry
         }
-        logger.debug("Loaded %d game(s) from Playnite (%s)", len(games), path)
+        logger.info("Loaded %d game(s) from Playnite (%s)", len(games), path)
         _playnite_cache = (mtime, games)
         return games
     except Exception as e:
-        logger.debug("Could not load Playnite games from %s: %s", path, e)
+        logger.warning("Could not load Playnite games from %s: %s", path, e)
         return {}
 
 

--- a/game_detector.py
+++ b/game_detector.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 
 import psutil
 
@@ -11,64 +10,64 @@ from config import KNOWN_GAMES
 
 logger = logging.getLogger(__name__)
 
-# Playnite JSON cache: (mtime, parsed_dict)
-_playnite_cache: tuple[float, dict[str, str]] | None = None
+_current_game_logged_missing = False
 
 
-def _load_playnite_games() -> dict[str, str]:
+def _get_playnite_current_game() -> dict | None:
     """
-    Reads the Playnite-exported JSON and returns {process_lower: display_name}.
-    Result is cached and only reloaded when the file's mtime changes.
-    Returns {} silently if the file is missing or malformed.
+    Reads the file the Playnite plugin writes when a game starts.
+    Validates the PID is still alive to guard against stale files.
+    Returns a game dict or None.
     """
-    global _playnite_cache
-    path = config.get_playnite_games_path()
-    try:
-        mtime = os.path.getmtime(path)
-    except OSError:
-        if _playnite_cache is None:
-            logger.info("Playnite games file not found: %s", path)
-        return {}
-
-    if _playnite_cache is not None and _playnite_cache[0] == mtime:
-        return _playnite_cache[1]
-
+    global _current_game_logged_missing
+    path = config.get_playnite_current_game_path()
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
-        games = {
-            entry["process"].lower(): entry["name"]
-            for entry in data
-            if "process" in entry and "name" in entry
-        }
-        logger.info("Loaded %d game(s) from Playnite (%s)", len(games), path)
-        _playnite_cache = (mtime, games)
-        return games
+
+        pid = data.get("pid")
+        if pid is not None and not psutil.pid_exists(pid):
+            logger.debug("Playnite current game file has stale PID %d — ignoring", pid)
+            return None
+
+        _current_game_logged_missing = False
+        return {"process": data["process"], "display_name": data["name"]}
+
+    except FileNotFoundError:
+        if not _current_game_logged_missing:
+            logger.info("Playnite current game file not found: %s", path)
+            _current_game_logged_missing = True
+        return None
     except Exception as e:
-        logger.warning("Could not load Playnite games from %s: %s", path, e)
-        return {}
+        logger.debug("Could not read Playnite current game from %s: %s", path, e)
+        return None
 
 
 def get_running_game() -> dict | None:
     """
-    Checks running processes against the known games list (manual config merged
-    with Playnite data). Manual [games] entries take precedence over Playnite.
-    Returns the first match as a dict, or None if no known game is running.
+    Returns the currently running game as a dict, or None.
+
+    Checks in order:
+    1. Playnite event-driven file (euterpium_current_game.json) — covers all
+       games launched via Playnite regardless of platform.
+    2. Manual [games] entries from euterpium.ini — covers games launched
+       outside Playnite.
     """
-    playnite_games = _load_playnite_games()
-    known_games = {**playnite_games, **KNOWN_GAMES}
+    game = _get_playnite_current_game()
+    if game:
+        return game
+
+    if not KNOWN_GAMES:
+        return None
 
     try:
         for proc in psutil.process_iter(["name"]):
             proc_name = (proc.info.get("name", "") or "").lower()
-            if proc_name in known_games:
-                return {
-                    "process": proc_name,
-                    "display_name": known_games[proc_name],
-                }
+            if proc_name in KNOWN_GAMES:
+                return {"process": proc_name, "display_name": KNOWN_GAMES[proc_name]}
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         pass
     except Exception as e:
-        logger.debug(f"Process scan error: {e}")
+        logger.debug("Process scan error: %s", e)
 
     return None

--- a/main.py
+++ b/main.py
@@ -20,11 +20,11 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     datefmt="%H:%M:%S",
 )
-logging.getLogger("smtc").setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
 def main():
+    logging.getLogger().setLevel(config.get_log_level())
     logger.info("Starting Euterpium %s", __version__)
 
     # Report winsdk status now that logging is definitely active

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Events;
@@ -13,10 +15,19 @@ namespace EuterpiumExporter
     {
         private static readonly ILogger logger = LogManager.GetLogger();
 
-        private readonly string _exportPath = Path.Combine(
+        // Exe name substrings (lowercase) that are never the main game executable,
+        // used as a fallback when Playnite doesn't provide a process ID.
+        private static readonly string[] _nonGameExePatterns = new[]
+        {
+            "unins", "setup", "install", "redist", "vcredist", "dxsetup",
+            "dotnet", "crash", "report", "helper", "launcher_fixes",
+            "steam_", "easyanticheat", "battleye", "be_service",
+        };
+
+        private readonly string _currentGamePath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "Playnite",
-            "euterpium_games.json"
+            "euterpium_current_game.json"
         );
 
         public override Guid Id { get; } = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
@@ -25,63 +36,142 @@ namespace EuterpiumExporter
 
         public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
         {
-            ExportGames();
-            PlayniteApi.Database.Games.ItemCollectionChanged += (_, __) => ExportGames();
-            PlayniteApi.Database.Games.ItemUpdated += (_, __) => ExportGames();
+            // Clear any stale file left by a previous crash
+            if (File.Exists(_currentGamePath))
+            {
+                File.Delete(_currentGamePath);
+                logger.Info("EuterpiumExporter: cleared stale current game file on startup");
+            }
+
+            logger.Info("EuterpiumExporter: ready");
         }
 
-        private void ExportGames()
+        public override void OnGameStarted(OnGameStartedEventArgs args)
         {
-            try
-            {
-                var entries = new List<GameEntry>();
+            var game = args.Game;
+            string exeName = null;
 
-                foreach (var game in PlayniteApi.Database.Games)
+            // Prefer the actual process name from the PID Playnite gives us
+            if (args.StartedProcessId.HasValue)
+            {
+                try
                 {
-                    if (game.GameActions == null)
+                    var proc = Process.GetProcessById(args.StartedProcessId.Value);
+                    exeName = proc.MainModule?.ModuleName;
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"EuterpiumExporter: could not get process name from PID {args.StartedProcessId}: {ex.Message}");
+                }
+            }
+
+            // Fall back to resolving from game configuration / install directory
+            if (string.IsNullOrWhiteSpace(exeName))
+                exeName = FindGameExe(game);
+
+            if (string.IsNullOrWhiteSpace(exeName))
+            {
+                logger.Warn($"EuterpiumExporter: could not determine exe for '{game.Name}' — game will not be detected");
+                return;
+            }
+
+            var entry = new CurrentGameEntry
+            {
+                Process = exeName,
+                Name = game.Name,
+                Pid = args.StartedProcessId,
+            };
+
+            File.WriteAllText(_currentGamePath, JsonConvert.SerializeObject(entry, Formatting.Indented));
+            logger.Info($"EuterpiumExporter: game started — {game.Name} ({exeName})");
+        }
+
+        public override void OnGameStopped(OnGameStoppedEventArgs args)
+        {
+            if (File.Exists(_currentGamePath))
+                File.Delete(_currentGamePath);
+
+            logger.Info($"EuterpiumExporter: game stopped — {args.Game.Name}");
+        }
+
+        // Fallback exe resolution when Playnite doesn't provide a process ID.
+        // Tries explicit File-type play actions first, then scans the install directory.
+        private string FindGameExe(Game game)
+        {
+            if (game.GameActions != null)
+            {
+                foreach (var action in game.GameActions)
+                {
+                    if (!action.IsPlayAction || action.Type != GameActionType.File)
                         continue;
 
-                    foreach (var action in game.GameActions)
-                    {
-                        if (!action.IsPlayAction || action.Type != GameActionType.File)
-                            continue;
+                    var resolved = PlayniteApi.ExpandGameVariables(game, action.Path);
+                    if (string.IsNullOrWhiteSpace(resolved))
+                        continue;
 
-                        var resolvedPath = PlayniteApi.ExpandGameVariables(game, action.Path);
-                        if (string.IsNullOrWhiteSpace(resolvedPath))
-                            continue;
-
-                        var exe = Path.GetFileName(resolvedPath);
-                        if (string.IsNullOrWhiteSpace(exe))
-                            continue;
-
-                        entries.Add(new GameEntry { Process = exe, Name = game.Name });
-                        break; // one entry per game
-                    }
+                    var exe = Path.GetFileName(resolved);
+                    if (!string.IsNullOrWhiteSpace(exe))
+                        return exe;
                 }
+            }
 
-                var json = JsonConvert.SerializeObject(entries, Formatting.Indented);
-                var dir = Path.GetDirectoryName(_exportPath);
-                var tmp = Path.Combine(dir, Path.GetRandomFileName());
-                File.WriteAllText(tmp, json);
-                if (File.Exists(_exportPath))
-                    File.Replace(tmp, _exportPath, null);
-                else
-                    File.Move(tmp, _exportPath);
-                logger.Info($"EuterpiumExporter: exported {entries.Count} game(s) to {_exportPath}");
+            if (string.IsNullOrWhiteSpace(game.InstallDirectory) ||
+                !Directory.Exists(game.InstallDirectory))
+                return null;
+
+            try
+            {
+                var candidates = Directory
+                    .GetFiles(game.InstallDirectory, "*.exe", SearchOption.TopDirectoryOnly)
+                    .Select(Path.GetFileName)
+                    .Where(f => !IsNonGameExe(f))
+                    .ToList();
+
+                if (candidates.Count == 1)
+                    return candidates[0];
+
+                if (candidates.Count > 1)
+                {
+                    var slug = new string(game.Name
+                        .ToLowerInvariant()
+                        .Where(char.IsLetterOrDigit)
+                        .ToArray());
+
+                    return candidates.FirstOrDefault(f =>
+                    {
+                        var nameSlug = new string(
+                            Path.GetFileNameWithoutExtension(f)
+                                .ToLowerInvariant()
+                                .Where(char.IsLetterOrDigit)
+                                .ToArray());
+                        return nameSlug.Contains(slug) || slug.Contains(nameSlug);
+                    });
+                }
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "EuterpiumExporter: failed to export games");
+                logger.Warn($"EuterpiumExporter: could not scan install dir for '{game.Name}': {ex.Message}");
             }
+
+            return null;
+        }
+
+        private static bool IsNonGameExe(string filename)
+        {
+            var lower = filename.ToLowerInvariant();
+            return _nonGameExePatterns.Any(p => lower.Contains(p));
         }
     }
 
-    internal class GameEntry
+    internal class CurrentGameEntry
     {
         [JsonProperty("process")]
         public string Process { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonProperty("pid")]
+        public int? Pid { get; set; }
     }
 }

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -39,8 +39,15 @@ namespace EuterpiumExporter
             // Clear any stale file left by a previous crash
             if (File.Exists(_currentGamePath))
             {
-                File.Delete(_currentGamePath);
-                logger.Info("EuterpiumExporter: cleared stale current game file on startup");
+                try
+                {
+                    File.Delete(_currentGamePath);
+                    logger.Info("EuterpiumExporter: cleared stale current game file on startup");
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"EuterpiumExporter: failed to clear stale current game file '{_currentGamePath}': {ex.Message}");
+                }
             }
 
             logger.Info("EuterpiumExporter: ready");

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -82,10 +82,47 @@ namespace EuterpiumExporter
                 Pid = args.StartedProcessId,
             };
 
-            File.WriteAllText(_currentGamePath, JsonConvert.SerializeObject(entry, Formatting.Indented));
+            var currentGameJson = JsonConvert.SerializeObject(entry, Formatting.Indented);
+            WriteCurrentGameFileAtomically(currentGameJson);
             logger.Info($"EuterpiumExporter: game started — {game.Name} ({exeName})");
         }
 
+        private void WriteCurrentGameFileAtomically(string contents)
+        {
+            var directory = Path.GetDirectoryName(_currentGamePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var tempPath = Path.Combine(
+                directory ?? string.Empty,
+                Path.GetFileName(_currentGamePath) + "." + Guid.NewGuid().ToString("N") + ".tmp"
+            );
+
+            try
+            {
+                File.WriteAllText(tempPath, contents);
+
+                if (File.Exists(_currentGamePath))
+                {
+                    File.Replace(tempPath, _currentGamePath, null);
+                }
+                else
+                {
+                    File.Move(tempPath, _currentGamePath);
+                }
+            }
+            catch
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+
+                throw;
+            }
+        }
         public override void OnGameStopped(OnGameStoppedEventArgs args)
         {
             if (File.Exists(_currentGamePath))

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Events;

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -37,19 +37,7 @@ namespace EuterpiumExporter
         public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
         {
             // Clear any stale file left by a previous crash
-            if (File.Exists(_currentGamePath))
-            {
-                try
-                {
-                    File.Delete(_currentGamePath);
-                    logger.Info("EuterpiumExporter: cleared stale current game file on startup");
-                }
-                catch (Exception ex)
-                {
-                    logger.Warn($"EuterpiumExporter: failed to clear stale current game file '{_currentGamePath}': {ex.Message}");
-                }
-            }
-
+            TryDeleteCurrentGameFile("startup");
             logger.Info("EuterpiumExporter: ready");
         }
 
@@ -130,12 +118,27 @@ namespace EuterpiumExporter
                 throw;
             }
         }
+
         public override void OnGameStopped(OnGameStoppedEventArgs args)
         {
-            if (File.Exists(_currentGamePath))
-                File.Delete(_currentGamePath);
-
+            TryDeleteCurrentGameFile($"game stopped — {args.Game.Name}");
             logger.Info($"EuterpiumExporter: game stopped — {args.Game.Name}");
+        }
+
+        private void TryDeleteCurrentGameFile(string context)
+        {
+            if (!File.Exists(_currentGamePath))
+                return;
+
+            try
+            {
+                File.Delete(_currentGamePath);
+                logger.Info($"EuterpiumExporter: current game file deleted ({context})");
+            }
+            catch (Exception ex)
+            {
+                logger.Warn($"EuterpiumExporter: failed to delete current game file ({context}): {ex.Message}");
+            }
         }
 
         // Fallback exe resolution when Playnite doesn't provide a process ID.

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -15,13 +15,14 @@ namespace EuterpiumExporter
     {
         private static readonly ILogger logger = LogManager.GetLogger();
 
-        // Exe name substrings (lowercase) that are never the main game executable,
-        // used as a fallback when Playnite doesn't provide a process ID.
+        // Exe name substrings (lowercase) for distinctive support binaries that are
+        // not the main game executable, used as a fallback when Playnite doesn't
+        // provide a process ID. Keep these specific to avoid excluding real games.
         private static readonly string[] _nonGameExePatterns = new[]
         {
             "unins", "setup", "install", "redist", "vcredist", "dxsetup",
-            "dotnet", "crash", "report", "helper", "launcher_fixes",
-            "steam_", "easyanticheat", "battleye", "be_service",
+            "dotnet", "crashreporter", "crashpad_handler", "reporter", "launcher_fixes",
+            "steam_", "easyanticheat", "eac_launcher", "battleye", "be_service",
         };
 
         private readonly string _currentGamePath = Path.Combine(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 # tests/test_config.py — config read/write, profiles, migration, validation
 
+import logging
+
 import config
 
 # ── Configured checks ─────────────────────────────────────────────────────────
@@ -177,3 +179,25 @@ def test_getint_returns_valid_value(tmp_config):
     config.save({"audio": {"sample_rate": "22050"}})
     cfg = config._load()
     assert config._getint(cfg, "audio", "sample_rate", 44100) == 22050
+
+
+# ── Logging level ─────────────────────────────────────────────────────────────
+
+
+def test_get_log_level_default_is_info(tmp_config):
+    assert config.get_log_level() == logging.INFO
+
+
+def test_get_log_level_returns_debug(tmp_config):
+    config.save({"logging": {"level": "DEBUG"}})
+    assert config.get_log_level() == logging.DEBUG
+
+
+def test_get_log_level_case_insensitive(tmp_config):
+    config.save({"logging": {"level": "warning"}})
+    assert config.get_log_level() == logging.WARNING
+
+
+def test_get_log_level_falls_back_to_info_on_invalid(tmp_config):
+    config.save({"logging": {"level": "NOTAVALIDLEVEL"}})
+    assert config.get_log_level() == logging.INFO

--- a/tests/test_game_detector.py
+++ b/tests/test_game_detector.py
@@ -1,7 +1,7 @@
 # tests/test_game_detector.py — process scanning and game matching
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import psutil
 
@@ -9,54 +9,125 @@ import game_detector
 
 
 def _proc(name):
+    from unittest.mock import MagicMock
+
     mock = MagicMock()
     mock.info = {"name": name}
     return mock
 
 
-# ── Basic detection ───────────────────────────────────────────────────────────
+def _current_game_file(tmp_path, process, name, pid=None):
+    """Write a current game file and return the path."""
+    data = {"process": process, "name": name}
+    if pid is not None:
+        data["pid"] = pid
+    p = tmp_path / "euterpium_current_game.json"
+    p.write_text(json.dumps(data))
+    return str(p)
 
 
-def test_returns_none_when_no_known_game_running(monkeypatch):
+# ── Playnite event-driven detection ──────────────────────────────────────────
+
+
+def test_detects_game_from_playnite_current_game_file(monkeypatch, tmp_path):
+    path = _current_game_file(tmp_path, "witcher3.exe", "The Witcher 3")
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: path)
+    result = game_detector.get_running_game()
+    assert result == {"process": "witcher3.exe", "display_name": "The Witcher 3"}
+
+
+def test_playnite_current_game_file_missing_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
+    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {})
+    result = game_detector.get_running_game()
+    assert result is None
+
+
+def test_playnite_current_game_pid_validated_against_live_processes(monkeypatch, tmp_path):
+    path = _current_game_file(tmp_path, "game.exe", "My Game", pid=99999999)
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: path)
+    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {})
+    # PID 99999999 almost certainly doesn't exist
+    with patch("psutil.pid_exists", return_value=False):
+        result = game_detector.get_running_game()
+    assert result is None
+
+
+def test_playnite_current_game_with_valid_pid_is_returned(monkeypatch, tmp_path):
+    path = _current_game_file(tmp_path, "game.exe", "My Game", pid=1234)
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: path)
+    with patch("psutil.pid_exists", return_value=True):
+        result = game_detector.get_running_game()
+    assert result == {"process": "game.exe", "display_name": "My Game"}
+
+
+def test_playnite_current_game_without_pid_is_trusted(monkeypatch, tmp_path):
+    path = _current_game_file(tmp_path, "game.exe", "My Game")  # no pid
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: path)
+    result = game_detector.get_running_game()
+    assert result == {"process": "game.exe", "display_name": "My Game"}
+
+
+def test_playnite_current_game_malformed_falls_back(monkeypatch, tmp_path):
+    bad = tmp_path / "euterpium_current_game.json"
+    bad.write_text("not valid json{{")
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: str(bad))
+    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"game.exe": "My Game"})
+    with patch("psutil.process_iter", return_value=[_proc("game.exe")]):
+        result = game_detector.get_running_game()
+    assert result == {"process": "game.exe", "display_name": "My Game"}
+
+
+# ── Manual [games] fallback ───────────────────────────────────────────────────
+
+
+def test_falls_back_to_manual_games_when_no_current_game_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
     monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"ffxiv_dx11.exe": "Final Fantasy XIV"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
-    with patch("psutil.process_iter", return_value=[_proc("notepad.exe"), _proc("chrome.exe")]):
-        assert game_detector.get_running_game() is None
-
-
-def test_detects_known_game(monkeypatch):
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"ffxiv_dx11.exe": "Final Fantasy XIV"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
     with patch("psutil.process_iter", return_value=[_proc("ffxiv_dx11.exe")]):
         result = game_detector.get_running_game()
     assert result == {"process": "ffxiv_dx11.exe", "display_name": "Final Fantasy XIV"}
 
 
-def test_returns_first_match_when_multiple_games_running(monkeypatch):
+def test_playnite_takes_priority_over_manual_games(monkeypatch, tmp_path):
+    path = _current_game_file(tmp_path, "bg3.exe", "Baldur's Gate 3 (Playnite)")
+    monkeypatch.setattr("config.get_playnite_current_game_path", lambda: path)
+    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"bg3.exe": "Baldur's Gate 3 (Manual)"})
+    result = game_detector.get_running_game()
+    assert result["display_name"] == "Baldur's Gate 3 (Playnite)"
+
+
+def test_returns_none_when_no_known_game_running(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        game_detector,
-        "KNOWN_GAMES",
-        {
-            "game_a.exe": "Game A",
-            "game_b.exe": "Game B",
-        },
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
     )
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
-    with patch("psutil.process_iter", return_value=[_proc("game_a.exe"), _proc("game_b.exe")]):
-        result = game_detector.get_running_game()
-    assert result["process"] == "game_a.exe"
-
-
-def test_returns_none_when_process_list_is_empty(monkeypatch):
     monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"ffxiv_dx11.exe": "Final Fantasy XIV"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
-    with patch("psutil.process_iter", return_value=[]):
+    with patch("psutil.process_iter", return_value=[_proc("notepad.exe")]):
         assert game_detector.get_running_game() is None
 
 
-def test_process_name_matching_is_case_insensitive(monkeypatch):
+def test_returns_none_when_no_games_configured(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
+    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {})
+    assert game_detector.get_running_game() is None
+
+
+def test_manual_process_matching_is_case_insensitive(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
     monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"rocketleague.exe": "Rocket League"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
     with patch("psutil.process_iter", return_value=[_proc("RocketLeague.exe")]):
         result = game_detector.get_running_game()
     assert result == {"process": "rocketleague.exe", "display_name": "Rocket League"}
@@ -65,140 +136,21 @@ def test_process_name_matching_is_case_insensitive(monkeypatch):
 # ── Error resilience ──────────────────────────────────────────────────────────
 
 
-def test_handles_no_such_process_gracefully(monkeypatch):
+def test_handles_no_such_process_gracefully(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
     monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"game.exe": "Game"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
     with patch("psutil.process_iter", side_effect=psutil.NoSuchProcess(pid=1)):
         assert game_detector.get_running_game() is None
 
 
-def test_handles_access_denied_gracefully(monkeypatch):
+def test_handles_access_denied_gracefully(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "config.get_playnite_current_game_path",
+        lambda: str(tmp_path / "nonexistent.json"),
+    )
     monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"game.exe": "Game"})
-    monkeypatch.setattr(game_detector, "_load_playnite_games", lambda: {})
     with patch("psutil.process_iter", side_effect=psutil.AccessDenied(pid=1)):
         assert game_detector.get_running_game() is None
-
-
-# ── Playnite integration ──────────────────────────────────────────────────────
-
-
-def test_detects_game_from_playnite_data(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(json.dumps([{"process": "bg3.exe", "name": "Baldur's Gate 3"}]))
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {})
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    with patch("psutil.process_iter", return_value=[_proc("bg3.exe")]):
-        result = game_detector.get_running_game()
-    assert result == {"process": "bg3.exe", "display_name": "Baldur's Gate 3"}
-
-
-def test_manual_games_override_playnite(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(
-        json.dumps([{"process": "bg3.exe", "name": "Baldur's Gate 3 (Playnite)"}])
-    )
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"bg3.exe": "Baldur's Gate 3 (Manual)"})
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    with patch("psutil.process_iter", return_value=[_proc("bg3.exe")]):
-        result = game_detector.get_running_game()
-    assert result["display_name"] == "Baldur's Gate 3 (Manual)"
-
-
-def test_missing_playnite_file_falls_back_gracefully(monkeypatch, tmp_path):
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"game.exe": "My Game"})
-    monkeypatch.setattr(
-        "config.get_playnite_games_path",
-        lambda: str(tmp_path / "nonexistent.json"),
-    )
-    with patch("psutil.process_iter", return_value=[_proc("game.exe")]):
-        result = game_detector.get_running_game()
-    assert result == {"process": "game.exe", "display_name": "My Game"}
-
-
-def test_malformed_playnite_file_falls_back_gracefully(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text("not valid json{{")
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {"game.exe": "My Game"})
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    with patch("psutil.process_iter", return_value=[_proc("game.exe")]):
-        result = game_detector.get_running_game()
-    assert result == {"process": "game.exe", "display_name": "My Game"}
-
-
-def test_playnite_process_matching_is_case_insensitive(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(json.dumps([{"process": "BG3.exe", "name": "Baldur's Gate 3"}]))
-    monkeypatch.setattr(game_detector, "KNOWN_GAMES", {})
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    with patch("psutil.process_iter", return_value=[_proc("bg3.exe")]):
-        result = game_detector.get_running_game()
-    assert result == {"process": "bg3.exe", "display_name": "Baldur's Gate 3"}
-
-
-def test_load_playnite_games_returns_empty_when_file_missing(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "config.get_playnite_games_path",
-        lambda: str(tmp_path / "nonexistent.json"),
-    )
-    assert game_detector._load_playnite_games() == {}
-
-
-def test_load_playnite_games_skips_entries_missing_fields(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(
-        json.dumps(
-            [
-                {"process": "good.exe", "name": "Good Game"},
-                {"process": "no_name.exe"},
-                {"name": "No Process"},
-                {},
-            ]
-        )
-    )
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    result = game_detector._load_playnite_games()
-    assert result == {"good.exe": "Good Game"}
-
-
-# ── Playnite cache ────────────────────────────────────────────────────────────
-
-
-def test_playnite_cache_avoids_reparse_on_same_mtime(monkeypatch, tmp_path):
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(json.dumps([{"process": "game.exe", "name": "Game"}]))
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    monkeypatch.setattr(game_detector, "_playnite_cache", None)
-
-    call_count = 0
-    real_load = json.load
-
-    def counting_load(f):
-        nonlocal call_count
-        call_count += 1
-        return real_load(f)
-
-    with patch("game_detector.json.load", side_effect=counting_load):
-        game_detector._load_playnite_games()
-        game_detector._load_playnite_games()
-
-    assert call_count == 1
-
-
-def test_playnite_cache_refreshes_when_mtime_changes(monkeypatch, tmp_path):
-    import os
-
-    games_file = tmp_path / "euterpium_games.json"
-    games_file.write_text(json.dumps([{"process": "old.exe", "name": "Old Game"}]))
-    monkeypatch.setattr("config.get_playnite_games_path", lambda: str(games_file))
-    monkeypatch.setattr(game_detector, "_playnite_cache", None)
-
-    first = game_detector._load_playnite_games()
-    assert first == {"old.exe": "Old Game"}
-
-    # Overwrite with new content and bump mtime so the cache key changes
-    games_file.write_text(json.dumps([{"process": "new.exe", "name": "New Game"}]))
-    mtime = os.path.getmtime(str(games_file))
-    os.utime(str(games_file), (mtime + 1, mtime + 1))
-
-    second = game_detector._load_playnite_games()
-    assert second == {"new.exe": "New Game"}


### PR DESCRIPTION
This pull request modernizes and improves the Playnite integration for Euterpium by switching from a static game library export to an event-driven "current game" detection model. The Playnite plugin now writes a file only when a game is running, which Euterpium reads to enable accurate, automatic game audio detection. The configuration and documentation are updated to match this new approach, and a configurable logging level is introduced.

**Playnite integration improvements:**

* The Playnite plugin now writes a `euterpium_current_game.json` file only when a game is running, and deletes it when the game stops. This enables real-time detection and more reliable game mode activation, replacing the previous static game library export. [[1]](diffhunk://#diff-46f756a6a99dff90a095db91115f580b6612224148cf76d1e8e549b6df17ef5bL16-R30) [[2]](diffhunk://#diff-46f756a6a99dff90a095db91115f580b6612224148cf76d1e8e549b6df17ef5bL28-R175) [[3]](diffhunk://#diff-2059295b01da0f494f2a333aaaa955374472ab1e2cb36374442477748740766dL3-R22) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R138)
* The plugin attempts to determine the correct executable name using the process ID, falling back to scanning the install directory if needed, and ignores known non-game executables. [[1]](diffhunk://#diff-46f756a6a99dff90a095db91115f580b6612224148cf76d1e8e549b6df17ef5bL16-R30) [[2]](diffhunk://#diff-46f756a6a99dff90a095db91115f580b6612224148cf76d1e8e549b6df17ef5bL28-R175)

**Configuration and documentation updates:**

* Configuration options and documentation are updated to reference the new `current_game_file` mechanism instead of the old `games_file`, with clear migration instructions and a note about future REST API support. [[1]](diffhunk://#diff-2059295b01da0f494f2a333aaaa955374472ab1e2cb36374442477748740766dL49-R67) [[2]](diffhunk://#diff-67e50835aeb1938d7759d1a5c6e540bb37c6d3fb54e2a7eadf6cb369198c1600L34-R40) [[3]](diffhunk://#diff-2059295b01da0f494f2a333aaaa955374472ab1e2cb36374442477748740766dL3-R22)

**Euterpium core changes:**

* The Python integration now reads the Playnite "current game" file, validates the process is still alive, and prioritizes this method for game detection, falling back to manual config entries if needed. [[1]](diffhunk://#diff-bb8fa9beea0d8f096fdebf5d6aa2d61e51d66c344899efda9719eb7316019234L14-R71) [[2]](diffhunk://#diff-bb8fa9beea0d8f096fdebf5d6aa2d61e51d66c344899efda9719eb7316019234L5) [[3]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482L212-R230)
* The path lookup for the Playnite file in `config.py` is updated to match the new file name and config key.

**Logging improvements:**

* A configurable logging level is added via the `[logging]` section in `euterpium.ini`, and is used to set the root logger level at startup. [[1]](diffhunk://#diff-67e50835aeb1938d7759d1a5c6e540bb37c6d3fb54e2a7eadf6cb369198c1600R1-R4) [[2]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R100-R112) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L23-R27)

These changes together make Playnite integration more robust, automatic, and user-friendly.