### PR TITLE
fix: C# build fixes, configurable log level, event-driven Playnite detection

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -1,0 +1,25 @@
+name: "[Tests] Playnite Plugin Build"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "playnite-plugin/**"
+  pull_request:
+    paths:
+      - "playnite-plugin/**"
+
+jobs:
+  build-plugin:
+    name: Build Playnite plugin
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.x"
+
+      - name: Build
+        run: dotnet build playnite-plugin\EuterpiumExporter.csproj --configuration Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,3 @@ jobs:
     with:
       python_version: "3.12"
     secrets: inherit # pragma: allowlist secret
-
-  build-plugin:
-    name: Build Playnite plugin
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "6.x"
-
-      - name: Build
-        run: dotnet build playnite-plugin\EuterpiumExporter.csproj --configuration Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,17 @@ jobs:
     with:
       python_version: "3.12"
     secrets: inherit # pragma: allowlist secret
+
+  build-plugin:
+    name: Build Playnite plugin
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.x"
+
+      - name: Build
+        run: dotnet build playnite-plugin\EuterpiumExporter.csproj --configuration Release

--- a/playnite-plugin/EuterpiumExporter.cs
+++ b/playnite-plugin/EuterpiumExporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Events;
@@ -47,16 +48,17 @@ namespace EuterpiumExporter
             string exeName = null;
 
             // Prefer the actual process name from the PID Playnite gives us
-            if (args.StartedProcessId.HasValue)
+            var pid = args.StartedProcessId;
+            if (pid > 0)
             {
                 try
                 {
-                    var proc = Process.GetProcessById(args.StartedProcessId.Value);
+                    var proc = Process.GetProcessById((int)pid);
                     exeName = proc.MainModule?.ModuleName;
                 }
                 catch (Exception ex)
                 {
-                    logger.Warn($"EuterpiumExporter: could not get process name from PID {args.StartedProcessId}: {ex.Message}");
+                    logger.Warn($"EuterpiumExporter: could not get process name from PID {pid}: {ex.Message}");
                 }
             }
 


### PR DESCRIPTION
## Summary

- Switches Playnite game detection from static JSON export to event-driven `OnGameStarted`/`OnGameStopped` — works for Steam, GOG, Epic, emulators; no more install-directory guessing
- Adds configurable log level via `[logging] level` in `euterpium.ini` (default: INFO)
- Fixes C# build errors: missing `using System.Linq` and `StartedProcessId` nullable compatibility
- Adds CI job to build the Playnite plugin on PRs touching `playnite-plugin/**`

## Test plan

- [ ] Rebuild Playnite plugin and restart Playnite — `euterpium_current_game.json` should be cleared on startup
- [ ] Launch a game via Playnite — file should appear; Euterpium should switch to fingerprinting mode
- [ ] Stop the game — file should be deleted
- [ ] Set `level = DEBUG` in `[logging]` section and restart Euterpium — debug logs should appear
- [ ] Verify CI plugin build job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)