### PR TITLE
test: improve coverage for fingerprint, updater, and app_resolver

### DIFF
--- a/app/tests/test_app_resolver.py
+++ b/app/tests/test_app_resolver.py
@@ -1,0 +1,254 @@
+# tests/test_app_resolver.py — resolve_app_name and resolution strategy coverage
+
+import sys
+
+import app_resolver
+
+# ── resolve_app_name edge cases ───────────────────────────────────────────────
+
+
+def test_resolve_app_name_whitespace_only_returns_unknown():
+    assert app_resolver.resolve_app_name("   ") == "unknown"
+
+
+def test_resolve_app_name_none_returns_unknown():
+    assert app_resolver.resolve_app_name(None) == "unknown"
+
+
+def test_resolve_app_name_returns_cleaned_fallback_without_exe():
+    # No exe match, no windowsapps/registry resolution — falls back to last dot-part
+    result = app_resolver.resolve_app_name("com.example.myapp!App")
+    assert result == "app"
+
+
+def test_resolve_app_name_lowercases_resolved_aumid(monkeypatch):
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", False)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    # Inject a fake winreg that returns a display name
+    class FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_query(key, name):
+        if name == "DisplayName":
+            return ("Apple Music", 1)
+        raise OSError
+
+    fake_winreg = type(
+        "winreg",
+        (),
+        {
+            "HKEY_CURRENT_USER": 0,
+            "HKEY_CLASSES_ROOT": 1,
+            "OpenKey": staticmethod(lambda hive, path: FakeKey()),
+            "QueryValueEx": staticmethod(fake_query),
+        },
+    )()
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+
+    result = app_resolver.resolve_app_name("AppleInc.AppleMusic_8wekyb3d8bbwe!App")
+    assert result == "apple music"
+
+
+# ── is_windowsapps_available ──────────────────────────────────────────────────
+
+
+def test_is_windowsapps_available_reflects_module_flag(monkeypatch):
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+    assert app_resolver.is_windowsapps_available() is True
+
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", False)
+    assert app_resolver.is_windowsapps_available() is False
+
+
+# ── _resolve_app_name_from_aumid ──────────────────────────────────────────────
+
+
+def test_resolve_from_aumid_returns_none_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert app_resolver._resolve_app_name_from_aumid("some.app.id") is None
+
+
+def test_resolve_from_aumid_uses_direct_lookup(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+
+    fake_windowsapps = type(
+        "windowsapps",
+        (),
+        {"find_app_by_id": staticmethod(lambda app_id: ("Spotify", "spotify_id"))},
+    )()
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+
+    result = app_resolver._resolve_app_name_from_aumid("SpotifyAB.SpotifyMusic_xxx!Spotify")
+    assert result == "Spotify"
+
+
+def test_resolve_from_aumid_falls_back_to_exact_match(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+
+    fake_windowsapps = type(
+        "windowsapps",
+        (),
+        {
+            "find_app_by_id": staticmethod(lambda app_id: "Application not found!"),
+            "get_apps": staticmethod(
+                lambda: {"Apple Music": "AppleInc.AppleMusic_8wekyb3d8bbwe!App"}
+            ),
+        },
+    )()
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+
+    result = app_resolver._resolve_app_name_from_aumid("AppleInc.AppleMusic_8wekyb3d8bbwe!App")
+    assert result == "Apple Music"
+
+
+def test_resolve_from_aumid_falls_back_to_partial_match(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+
+    fake_windowsapps = type(
+        "windowsapps",
+        (),
+        {
+            "find_app_by_id": staticmethod(lambda app_id: "Application not found!"),
+            "get_apps": staticmethod(
+                lambda: {"Apple Music": "AppleInc.AppleMusic_8wekyb3d8bbwe!App"}
+            ),
+        },
+    )()
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+
+    # Partial match — the query id is a substring of the registered aid
+    result = app_resolver._resolve_app_name_from_aumid("AppleInc.AppleMusic_8wekyb3d8bbwe")
+    assert result == "Apple Music"
+
+
+def test_resolve_from_aumid_falls_back_to_registry_when_no_match(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+
+    fake_windowsapps = type(
+        "windowsapps",
+        (),
+        {
+            "find_app_by_id": staticmethod(lambda app_id: "Application not found!"),
+            "get_apps": staticmethod(lambda: {}),
+        },
+    )()
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    # Patch registry to return None
+    monkeypatch.setattr(app_resolver, "_resolve_from_registry", lambda app_id: None)
+
+    result = app_resolver._resolve_app_name_from_aumid("unknown.app.id")
+    assert result is None
+
+
+def test_resolve_from_aumid_falls_back_to_registry_on_windowsapps_exception(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(app_resolver, "WINDOWSAPPS_AVAILABLE", True)
+
+    fake_windowsapps = type(
+        "windowsapps",
+        (),
+        {
+            "find_app_by_id": staticmethod(
+                lambda app_id: (_ for _ in ()).throw(RuntimeError("oops"))
+            )
+        },
+    )()
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "_resolve_from_registry", lambda app_id: "fallback")
+
+    result = app_resolver._resolve_app_name_from_aumid("some.app")
+    assert result == "fallback"
+
+
+# ── _resolve_from_registry ────────────────────────────────────────────────────
+
+
+def test_resolve_from_registry_returns_none_without_winreg(monkeypatch):
+    monkeypatch.setitem(sys.modules, "winreg", None)
+    assert app_resolver._resolve_from_registry("some.app") is None
+
+
+def test_resolve_from_registry_returns_display_name(monkeypatch):
+    class FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_query(key, name):
+        if name == "DisplayName":
+            return ("My App", 1)
+        raise OSError
+
+    fake_winreg = type(
+        "winreg",
+        (),
+        {
+            "HKEY_CURRENT_USER": 0,
+            "HKEY_CLASSES_ROOT": 1,
+            "OpenKey": staticmethod(lambda hive, path: FakeKey()),
+            "QueryValueEx": staticmethod(fake_query),
+        },
+    )()
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+
+    result = app_resolver._resolve_from_registry("some.app.id")
+    assert result == "My App"
+
+
+def test_resolve_from_registry_extracts_exe_from_relaunch_command(monkeypatch):
+    class FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_query(key, name):
+        if name == "RelaunchCommand":
+            return (r"C:\Program Files\MyApp\myapp.exe --launch", 1)
+        raise OSError
+
+    fake_winreg = type(
+        "winreg",
+        (),
+        {
+            "HKEY_CURRENT_USER": 0,
+            "HKEY_CLASSES_ROOT": 1,
+            "OpenKey": staticmethod(lambda hive, path: FakeKey()),
+            "QueryValueEx": staticmethod(fake_query),
+        },
+    )()
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+
+    result = app_resolver._resolve_from_registry("some.app.id")
+    assert result == "myapp.exe"
+
+
+def test_resolve_from_registry_returns_none_when_key_missing(monkeypatch):
+    def raise_oserror(hive, path):
+        raise OSError("key not found")
+
+    fake_winreg = type(
+        "winreg",
+        (),
+        {
+            "HKEY_CURRENT_USER": 0,
+            "HKEY_CLASSES_ROOT": 1,
+            "OpenKey": staticmethod(raise_oserror),
+        },
+    )()
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+
+    result = app_resolver._resolve_from_registry("missing.app")
+    assert result is None

--- a/app/tests/test_app_resolver.py
+++ b/app/tests/test_app_resolver.py
@@ -173,7 +173,7 @@ def test_resolve_from_aumid_falls_back_to_registry_on_windowsapps_exception(monk
 
 
 def test_resolve_from_registry_returns_none_without_winreg(monkeypatch):
-    monkeypatch.setitem(sys.modules, "winreg", None)
+    monkeypatch.delitem(sys.modules, "winreg", raising=False)
     assert app_resolver._resolve_from_registry("some.app") is None
 
 

--- a/app/tests/test_app_resolver.py
+++ b/app/tests/test_app_resolver.py
@@ -82,7 +82,7 @@ def test_resolve_from_aumid_uses_direct_lookup(monkeypatch):
         (),
         {"find_app_by_id": staticmethod(lambda app_id: ("Spotify", "spotify_id"))},
     )()
-    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps, raising=False)
 
     result = app_resolver._resolve_app_name_from_aumid("SpotifyAB.SpotifyMusic_xxx!Spotify")
     assert result == "Spotify"
@@ -102,7 +102,7 @@ def test_resolve_from_aumid_falls_back_to_exact_match(monkeypatch):
             ),
         },
     )()
-    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps, raising=False)
 
     result = app_resolver._resolve_app_name_from_aumid("AppleInc.AppleMusic_8wekyb3d8bbwe!App")
     assert result == "Apple Music"
@@ -122,7 +122,7 @@ def test_resolve_from_aumid_falls_back_to_partial_match(monkeypatch):
             ),
         },
     )()
-    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps, raising=False)
 
     # Partial match — the query id is a substring of the registered aid
     result = app_resolver._resolve_app_name_from_aumid("AppleInc.AppleMusic_8wekyb3d8bbwe")
@@ -141,7 +141,7 @@ def test_resolve_from_aumid_falls_back_to_registry_when_no_match(monkeypatch):
             "get_apps": staticmethod(lambda: {}),
         },
     )()
-    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps, raising=False)
     # Patch registry to return None
     monkeypatch.setattr(app_resolver, "_resolve_from_registry", lambda app_id: None)
 
@@ -162,7 +162,7 @@ def test_resolve_from_aumid_falls_back_to_registry_on_windowsapps_exception(monk
             )
         },
     )()
-    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps)
+    monkeypatch.setattr(app_resolver, "windowsapps", fake_windowsapps, raising=False)
     monkeypatch.setattr(app_resolver, "_resolve_from_registry", lambda app_id: "fallback")
 
     result = app_resolver._resolve_app_name_from_aumid("some.app")

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -4,6 +4,9 @@ import base64
 import hashlib
 import hmac
 
+import pytest
+
+import fingerprint
 from fingerprint import _build_signature
 
 # ── Signature generation ──────────────────────────────────────────────────────
@@ -51,3 +54,138 @@ def test_build_signature_is_base64():
     # Should decode without error
     decoded = base64.b64decode(sig)
     assert len(decoded) == 20  # SHA-1 digest is 20 bytes
+
+
+# ── identify_audio ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def configured_credentials(monkeypatch):
+    """Patch config to return valid ACRCloud credentials."""
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_access_key", lambda: "mykey")
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_access_secret", lambda: "mysecret")
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_host", lambda: "identify.acrcloud.com")
+    monkeypatch.setattr(fingerprint.time, "time", lambda: 1700000000)
+
+
+def _make_response(json_data, status_code=200):
+    class FakeResponse:
+        def raise_for_status(self):
+            if status_code >= 400:
+                raise fingerprint.requests.HTTPError(response=self)
+
+        def json(self):
+            return json_data
+
+    return FakeResponse()
+
+
+def test_identify_audio_returns_none_when_not_configured(monkeypatch):
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_access_key", lambda: "")
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_access_secret", lambda: "")
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_host", lambda: "identify.acrcloud.com")
+    assert fingerprint.identify_audio(b"audio") is None
+
+
+def test_identify_audio_returns_none_on_request_exception(monkeypatch, configured_credentials):
+    def raise_exc(*args, **kwargs):
+        raise fingerprint.requests.RequestException("network error")
+
+    monkeypatch.setattr(fingerprint.requests, "post", raise_exc)
+    assert fingerprint.identify_audio(b"audio") is None
+
+
+def test_identify_audio_returns_none_on_no_match(monkeypatch, configured_credentials):
+    response = _make_response({"status": {"code": 1001, "msg": "No result"}})
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    assert fingerprint.identify_audio(b"audio") is None
+
+
+def test_identify_audio_returns_none_on_error_status(monkeypatch, configured_credentials):
+    response = _make_response({"status": {"code": 3000, "msg": "Internal error"}})
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    assert fingerprint.identify_audio(b"audio") is None
+
+
+def test_identify_audio_returns_result_on_success(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "Answers",
+                        "artists": [{"name": "Susan Calloway"}],
+                        "album": {"name": "Final Fantasy XIV"},
+                        "release_date": "2013-09-10",
+                        "acrid": "abc123",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+
+    result = fingerprint.identify_audio(b"audio")
+
+    assert result is not None
+    assert result["source"] == "acrcloud"
+    assert result["title"] == "Answers"
+    assert result["artist"] == "Susan Calloway"
+    assert result["album"] == "Final Fantasy XIV"
+    assert result["release_date"] == "2013-09-10"
+    assert result["acrid"] == "abc123"
+    assert result["streaming_links"] == {}
+
+
+def test_identify_audio_includes_streaming_links(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "Answers",
+                        "artists": [{"name": "Susan Calloway"}],
+                        "album": {},
+                        "release_date": "",
+                        "acrid": "abc123",
+                        "external_metadata": {
+                            "spotify": {"track": {"id": "spotify_track_id"}},
+                            "youtube": {"track": {"id": "youtube_video_id"}},
+                        },
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+
+    result = fingerprint.identify_audio(b"audio")
+
+    assert result is not None
+    assert result["streaming_links"] == {
+        "spotify": "spotify_track_id",
+        "youtube": "youtube_video_id",
+    }
+
+
+def test_identify_audio_returns_none_on_malformed_response(monkeypatch, configured_credentials):
+    # Missing expected keys in metadata
+    response = _make_response({"status": {"code": 0, "msg": "Success"}, "metadata": {}})
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    assert fingerprint.identify_audio(b"audio") is None
+
+
+def test_identify_audio_posts_to_correct_url(monkeypatch, configured_credentials):
+    posted_urls = []
+
+    def fake_post(url, **kwargs):
+        posted_urls.append(url)
+        return _make_response({"status": {"code": 1001, "msg": "No result"}})
+
+    monkeypatch.setattr(fingerprint.requests, "post", fake_post)
+    fingerprint.identify_audio(b"audio")
+
+    assert posted_urls == ["https://identify.acrcloud.com/v1/identify"]

--- a/app/tests/test_updater.py
+++ b/app/tests/test_updater.py
@@ -1,5 +1,6 @@
 import hashlib
 import queue
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -8,6 +9,8 @@ import pytest
 import requests
 
 import updater
+
+windows_only = pytest.mark.skipif(sys.platform != "win32", reason="os.startfile is Windows-only")
 
 
 def test_normalize_version_accepts_tag_prefix():
@@ -556,6 +559,7 @@ def test_download_installer_raises_on_checksum_fetch_error(monkeypatch, tmp_path
 # ── launch_installer ──────────────────────────────────────────────────────────
 
 
+@windows_only
 def test_launch_installer_calls_startfile(monkeypatch, tmp_path):
     launched = []
     monkeypatch.setattr(updater.os, "startfile", lambda p: launched.append(p))
@@ -565,6 +569,7 @@ def test_launch_installer_calls_startfile(monkeypatch, tmp_path):
     assert launched == [str(fake_installer)]
 
 
+@windows_only
 def test_launch_installer_raises_on_error(monkeypatch, tmp_path):
     def raise_exc(p):
         raise OSError("cannot launch")

--- a/app/tests/test_updater.py
+++ b/app/tests/test_updater.py
@@ -645,10 +645,12 @@ def test_install_worker_emits_launched_on_success(monkeypatch, tmp_path):
         installer_name="euterpium-v0.2.0-setup.exe",
         installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
     )
-    fake_path = tmp_path / "setup.exe"
+    update_tmp = tmp_path / "update-tmp"
+    update_tmp.mkdir()
+    fake_path = update_tmp / "setup.exe"
     monkeypatch.setattr(updater, "download_installer", lambda u, d: fake_path)
     monkeypatch.setattr(updater, "launch_installer", lambda p: None)
-    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(update_tmp))
 
     manager._install_worker(update)
 
@@ -671,7 +673,9 @@ def test_install_worker_emits_error_on_failure(monkeypatch, tmp_path):
         "download_installer",
         lambda u, d: (_ for _ in ()).throw(updater.UpdateError("download failed")),
     )
-    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+    update_tmp = tmp_path / "update-tmp"
+    update_tmp.mkdir()
+    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(update_tmp))
 
     manager._install_worker(update)
 

--- a/app/tests/test_updater.py
+++ b/app/tests/test_updater.py
@@ -1,7 +1,11 @@
 import hashlib
+import queue
+import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+import requests
 
 import updater
 
@@ -318,3 +322,355 @@ def test_update_manager_emits_update_checked_on_error(monkeypatch):
     assert ("update_checked", None) in events
     # No update_available should be emitted on error
     assert not any(e[0] == "update_available" for e in events)
+
+
+# ── cleanup_stale_update_dirs ─────────────────────────────────────────────────
+
+
+def test_cleanup_removes_old_dirs(tmp_path):
+    old_dir = tmp_path / f"{updater.UPDATE_TEMP_DIR_PREFIX}old"
+    old_dir.mkdir()
+    # Set mtime to 2 days ago
+    old_time = time.time() - 2 * 24 * 60 * 60
+    import os
+
+    os.utime(old_dir, (old_time, old_time))
+
+    with patch("updater.tempfile.gettempdir", return_value=str(tmp_path)):
+        removed = updater.cleanup_stale_update_dirs(max_age_seconds=60 * 60)
+
+    assert removed == 1
+    assert not old_dir.exists()
+
+
+def test_cleanup_skips_fresh_dirs(tmp_path):
+    fresh_dir = tmp_path / f"{updater.UPDATE_TEMP_DIR_PREFIX}fresh"
+    fresh_dir.mkdir()
+
+    with patch("updater.tempfile.gettempdir", return_value=str(tmp_path)):
+        removed = updater.cleanup_stale_update_dirs(max_age_seconds=24 * 60 * 60)
+
+    assert removed == 0
+    assert fresh_dir.exists()
+
+
+def test_cleanup_skips_non_dirs(tmp_path):
+    old_file = tmp_path / f"{updater.UPDATE_TEMP_DIR_PREFIX}file.txt"
+    old_file.write_text("x")
+    old_time = time.time() - 2 * 24 * 60 * 60
+    import os
+
+    os.utime(old_file, (old_time, old_time))
+
+    with patch("updater.tempfile.gettempdir", return_value=str(tmp_path)):
+        removed = updater.cleanup_stale_update_dirs(max_age_seconds=60 * 60)
+
+    assert removed == 0
+
+
+# ── normalize_version ─────────────────────────────────────────────────────────
+
+
+def test_normalize_version_raises_on_no_digits():
+    with pytest.raises(ValueError, match="Unsupported version string"):
+        updater.normalize_version("no-digits-here")
+
+
+def test_normalize_version_pads_short_version():
+    assert updater.normalize_version("1.2") == (1, 2, 0)
+
+
+# ── parse_latest_release ──────────────────────────────────────────────────────
+
+
+def test_parse_latest_release_returns_none_for_draft():
+    release = {
+        "draft": True,
+        "tag_name": "v0.2.0",
+        "assets": [
+            {
+                "name": "euterpium-v0.2.0-setup.exe",
+                "browser_download_url": "https://github.com/download/setup.exe",
+            }
+        ],
+    }
+    assert updater.parse_latest_release(release, "0.1.0") is None
+
+
+def test_parse_latest_release_raises_on_missing_download_url():
+    release = {
+        "tag_name": "v0.2.0",
+        "assets": [{"name": "euterpium-v0.2.0-setup.exe"}],  # no browser_download_url
+    }
+    with pytest.raises(updater.UpdateError):
+        updater.parse_latest_release(release, "0.1.0")
+
+
+def test_parse_latest_release_skips_checksum_with_bad_url():
+    release = {
+        "tag_name": "v0.2.0",
+        "html_url": "https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        "assets": [
+            {
+                "name": "euterpium-v0.2.0-setup.exe",
+                "browser_download_url": "https://github.com/download/setup.exe",
+            },
+            {
+                "name": "euterpium-v0.2.0-setup.exe.sha256",
+                "browser_download_url": "https://evil.example.com/checksums/setup.exe.sha256",
+            },
+        ],
+    }
+    update = updater.parse_latest_release(release, "0.1.0")
+    # Bad checksum URL should be silently skipped, not raise
+    assert update is not None
+    assert update.checksum_url is None
+
+
+# ── fetch_latest_update ───────────────────────────────────────────────────────
+
+
+def test_fetch_latest_update_raises_on_invalid_json(monkeypatch):
+    class BadJsonResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            raise ValueError("not json")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(updater.requests, "get", lambda *a, **kw: BadJsonResponse())
+
+    with pytest.raises(updater.UpdateError, match="invalid JSON"):
+        updater.fetch_latest_update("0.1.0")
+
+
+def test_fetch_latest_update_raises_on_network_error(monkeypatch):
+    def raise_exc(*a, **kw):
+        raise requests.RequestException("timeout")
+
+    monkeypatch.setattr(updater.requests, "get", raise_exc)
+
+    with pytest.raises(updater.UpdateError, match="Unable to reach"):
+        updater.fetch_latest_update("0.1.0")
+
+
+# ── download_installer error paths ───────────────────────────────────────────
+
+
+def test_download_installer_raises_on_request_error(monkeypatch, tmp_path):
+    def raise_exc(*a, **kw):
+        raise requests.RequestException("connection refused")
+
+    monkeypatch.setattr(updater.requests, "get", raise_exc)
+    update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
+    )
+    with pytest.raises(updater.UpdateError, match="Failed to download"):
+        updater.download_installer(update, tmp_path)
+
+
+def test_download_installer_raises_on_empty_checksum(monkeypatch, tmp_path):
+    class InstallerResponse:
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=0):
+            yield b"content"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    class EmptyChecksumResponse:
+        text = ""
+
+        def raise_for_status(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        updater.requests,
+        "get",
+        lambda url, **kw: EmptyChecksumResponse() if "sha256" in url else InstallerResponse(),
+    )
+    update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
+        checksum_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe.sha256",
+    )
+    with pytest.raises(updater.UpdateError, match="empty or invalid"):
+        updater.download_installer(update, tmp_path)
+    assert not (tmp_path / "euterpium-v0.2.0-setup.exe").exists()
+
+
+def test_download_installer_raises_on_checksum_fetch_error(monkeypatch, tmp_path):
+    class InstallerResponse:
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=0):
+            yield b"content"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_get(url, **kw):
+        if "sha256" in url:
+            raise requests.RequestException("checksum fetch failed")
+        return InstallerResponse()
+
+    monkeypatch.setattr(updater.requests, "get", fake_get)
+    update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
+        checksum_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe.sha256",
+    )
+    with pytest.raises(updater.UpdateError, match="Failed to fetch.*checksum"):
+        updater.download_installer(update, tmp_path)
+    assert not (tmp_path / "euterpium-v0.2.0-setup.exe").exists()
+
+
+# ── launch_installer ──────────────────────────────────────────────────────────
+
+
+def test_launch_installer_calls_startfile(monkeypatch, tmp_path):
+    launched = []
+    monkeypatch.setattr(updater.os, "startfile", lambda p: launched.append(p))
+    fake_installer = tmp_path / "setup.exe"
+    fake_installer.write_bytes(b"")
+    updater.launch_installer(fake_installer)
+    assert launched == [str(fake_installer)]
+
+
+def test_launch_installer_raises_on_error(monkeypatch, tmp_path):
+    def raise_exc(p):
+        raise OSError("cannot launch")
+
+    monkeypatch.setattr(updater.os, "startfile", raise_exc)
+    with pytest.raises(updater.UpdateError, match="Failed to launch"):
+        updater.launch_installer(tmp_path / "setup.exe")
+
+
+# ── UpdateManager ─────────────────────────────────────────────────────────────
+
+
+def _make_manager(monkeypatch=None):
+    q = queue.Queue()
+    return updater.UpdateManager(event_queue=q, current_version="0.1.0"), q
+
+
+def test_get_available_update_initially_none():
+    manager, _ = _make_manager()
+    assert manager.get_available_update() is None
+
+
+def test_check_for_updates_deduplicates(monkeypatch):
+    manager, q = _make_manager()
+    manager._check_in_progress = True
+    # Should return early without starting a thread
+    manager.check_for_updates(manual=True)
+    assert q.get_nowait() == ("status", "Update check already in progress")
+
+
+def test_check_worker_emits_status_when_up_to_date(monkeypatch):
+    manager, q = _make_manager()
+    monkeypatch.setattr(updater, "fetch_latest_update", lambda v: None)
+    manager._check_worker(manual=True)
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert any(e[0] == "status" and "up to date" in e[1] for e in events)
+
+
+def test_check_worker_emits_error_on_failure_when_manual(monkeypatch):
+    manager, q = _make_manager()
+    monkeypatch.setattr(
+        updater, "fetch_latest_update", lambda v: (_ for _ in ()).throw(updater.UpdateError("fail"))
+    )
+    manager._check_worker(manual=True)
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert any(e[0] == "error" for e in events)
+
+
+def test_install_available_update_returns_early_when_in_progress():
+    manager, q = _make_manager()
+    manager._install_in_progress = True
+    manager.install_available_update()
+    event = q.get_nowait()
+    assert event == ("status", "Update installation already in progress")
+
+
+def test_install_available_update_returns_early_when_no_update():
+    manager, q = _make_manager()
+    manager.install_available_update()
+    event = q.get_nowait()
+    assert event == ("status", "No update available")
+
+
+def test_install_worker_emits_launched_on_success(monkeypatch, tmp_path):
+    manager, q = _make_manager()
+    update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
+    )
+    fake_path = tmp_path / "setup.exe"
+    monkeypatch.setattr(updater, "download_installer", lambda u, d: fake_path)
+    monkeypatch.setattr(updater, "launch_installer", lambda p: None)
+    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+
+    manager._install_worker(update)
+
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert any(e[0] == "update_installer_launched" for e in events)
+
+
+def test_install_worker_emits_error_on_failure(monkeypatch, tmp_path):
+    manager, q = _make_manager()
+    update = updater.AvailableUpdate(
+        version="0.2.0",
+        release_url="https://github.com/aquarion/euterpium/releases/tag/v0.2.0",
+        installer_name="euterpium-v0.2.0-setup.exe",
+        installer_url="https://github.com/aquarion/euterpium/releases/download/v0.2.0/euterpium-v0.2.0-setup.exe",
+    )
+    monkeypatch.setattr(
+        updater,
+        "download_installer",
+        lambda u, d: (_ for _ in ()).throw(updater.UpdateError("download failed")),
+    )
+    monkeypatch.setattr(updater.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+
+    manager._install_worker(update)
+
+    events = []
+    while not q.empty():
+        events.append(q.get_nowait())
+    assert any(e[0] == "error" for e in events)


### PR DESCRIPTION
Closes #28
Closes #29
Closes #32

## Summary

**`fingerprint.identify_audio`** — previously 0% covered. Now tests: missing credentials, network/request exceptions, no-match (1001) and error status codes, successful response parsing, streaming links extraction, malformed response, and correct URL construction.

**`updater.py`** — fills error-path and UpdateManager gaps: `cleanup_stale_update_dirs` (removes old, skips fresh/files), `normalize_version` (ValueError, short padding), `parse_latest_release` (draft, missing URL, bad checksum URL), `fetch_latest_update` (network error, invalid JSON), `download_installer` (request error, checksum fetch failure, empty checksum), `launch_installer` (success and OSError), and `UpdateManager` deduplication, worker status/error events, and install flow.

**`app_resolver.py`** — new `test_app_resolver.py`: whitespace/None inputs, fallback name cleaning, `windowsapps` direct/exact/partial match and exception fallback, `_resolve_from_registry` with DisplayName/RelaunchCommand/missing key, and `is_windowsapps_available`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)