### PR TITLE
ci: make build-plugin skippable for required check enforcement

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -3,15 +3,26 @@ name: "[Tests] Playnite Plugin Build"
 on:
   push:
     branches: [main]
-    paths:
-      - "playnite-plugin/**"
   pull_request:
-    paths:
-      - "playnite-plugin/**"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      plugin: ${{ steps.filter.outputs.plugin }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            plugin:
+              - "playnite-plugin/**"
+
   build-plugin:
     name: Build Playnite plugin
+    needs: changes
+    if: needs.changes.outputs.plugin == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Previously `test-plugin.yml` used an `on.paths` filter, which meant the workflow never ran on non-plugin PRs. This made it impossible to set `build-plugin` as a required status check without blocking every Python-only PR.

This replaces the path filter with a `dorny/paths-filter` changes-detection job that always runs (cheaply, on Ubuntu). The `build-plugin` Windows job is skipped when no `playnite-plugin/**` files changed — GitHub treats a skipped job as passing for required checks purposes.

**Effect:**
- Python-only PRs: `changes` runs (fast, Ubuntu), `build-plugin` is skipped ✓
- Plugin PRs: `changes` runs, `build-plugin` runs the real Windows build ✓
- `build-plugin` can now be added as a required status check in branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)