### PR TITLE
chore: document and suppress Newtonsoft.Json version pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     directory: "/playnite-plugin"
     schedule:
       interval: "weekly"
+    ignore:
+      # Pinned to match Playnite's bundled version — cannot upgrade independently
+      - dependency-name: "Newtonsoft.Json"
   - package-ecosystem: github-actions
     directory: "/" # Location of package manifests
     schedule:

--- a/playnite-plugin/EuterpiumExporter.csproj
+++ b/playnite-plugin/EuterpiumExporter.csproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="PlayniteSDK" Version="6.*" />
+    <!-- Pinned to 10.* to match Playnite's bundled version — the plugin runs inside
+         Playnite's process and uses its copy at runtime, so upgrading here would
+         build against a newer API than is actually available. -->
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #52 (supersedes the Dependabot upgrade PR).

Playnite bundles Newtonsoft.Json v10 and the plugin runs inside Playnite's process, so upgrading the package reference would build against a newer API than is available at runtime. The vulnerability alert can't be resolved here — it's on Playnite to update their dependency.

- Adds a comment in `EuterpiumExporter.csproj` explaining the pin
- Adds a Dependabot ignore rule so this PR doesn't keep reappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)