### PR TITLE
fix: use pull_request_target to trigger Dependabot auto-merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,15 +1,12 @@
 name: "[Auto] Merge Dependabot Updates"
 
 on:
-  workflow_run:
-    workflows: ["[Tests] Acceptance Testing"]
-    types:
-      - completed
-    branches-ignore:
-      - 'main'
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   automerge:
+    if: github.actor == 'dependabot[bot]'
     uses: istic/shared-workflows/.github/workflows/auto-merge-dependabot.yml@main
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   automerge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     uses: istic/shared-workflows/.github/workflows/auto-merge-dependabot.yml@main
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

The auto-merge workflow has never run because `workflow_run` only fires when the named workflow completes on the **default branch**. Dependabot PRs run the tests workflow on their own branch, which doesn't trigger this listener.

Switched to `pull_request_target` with `if: github.actor == 'dependabot[bot]'` — the standard pattern for Dependabot auto-merge. `pull_request_target` runs in the base branch context (so it has write access) and fires reliably for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)