### PR TITLE
Ensure target branch is set for all package ecosystems in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,19 @@ updates:
     directory: "/app"
     schedule:
       interval: "weekly"
+    target-branch: "dependabot-updates"
   - package-ecosystem: "nuget"
     directory: "/playnite-plugin"
     schedule:
       interval: "weekly"
+    target-branch: "dependabot-updates"
   - package-ecosystem: github-actions
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "dependabot-updates"
   - package-ecosystem: pre-commit
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "dependabot-updates"


### PR DESCRIPTION
This pull request makes a minor configuration update to the `.github/dependabot.yml` file. The change sets the `target-branch` for all package ecosystems to `dependabot-updates`, ensuring that all automated dependency updates are directed to a dedicated branch.

- Configuration update:
  * Set `target-branch` to `dependabot-updates` for all package ecosystems in `.github/dependabot.yml`…abot configuration