### PR TITLE
Update streaming links structure in identify_audio function and tests

### DIFF
--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -37,6 +37,12 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
 
     Result dict keys:
         title, artist, album, release_date, acrid, streaming_links
+
+    ``streaming_links`` contains the raw ACRCloud ``external_metadata`` object
+    verbatim — a dict keyed by platform (e.g. ``spotify``, ``deezer``,
+    ``youtube``, ``musicbrainz``) whose values are platform-specific nested
+    dicts/lists.  The exact shape depends on what ACRCloud returns for the
+    matched track.
     """
     # Read credentials fresh each call so settings changes take effect immediately
     access_key = config.get_acrcloud_access_key()

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -85,13 +85,6 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         artists = ", ".join(a["name"] for a in music.get("artists", []))
         album_info = music.get("album", {})
 
-        # Extract streaming links if available
-        streaming = {}
-        for platform, info in music.get("external_metadata", {}).items():
-            track_id = info.get("track", {}).get("id")
-            if track_id:
-                streaming[platform] = track_id
-
         return {
             "source": "acrcloud",
             "title": music.get("title", ""),
@@ -99,7 +92,7 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
             "album": album_info.get("name", ""),
             "release_date": music.get("release_date", ""),
             "acrid": music.get("acrid", ""),
-            "streaming_links": streaming,
+            "streaming_links": music.get("external_metadata", {}),
         }
 
     except (KeyError, IndexError) as e:

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -140,6 +140,20 @@ def test_identify_audio_returns_result_on_success(monkeypatch, configured_creden
 
 
 def test_identify_audio_includes_streaming_links(monkeypatch, configured_credentials):
+    external_metadata = {
+        "spotify": {
+            "track": {"id": "spotify_track_id"},
+            "artists": [{"id": "artist_id"}],
+            "album": {"id": "album_id"},
+        },
+        "deezer": {
+            "track": {"id": "deezer_track_id"},
+            "artists": [{"id": "artist_id"}],
+            "album": {"id": "album_id"},
+        },
+        "youtube": {"vid": "youtube_vid"},
+        "musicbrainz": [{"track": {"id": "mb_track_id"}}],
+    }
     response = _make_response(
         {
             "status": {"code": 0, "msg": "Success"},
@@ -151,12 +165,7 @@ def test_identify_audio_includes_streaming_links(monkeypatch, configured_credent
                         "album": {},
                         "release_date": "",
                         "acrid": "abc123",
-                        "external_metadata": {
-                            "spotify": {"track": {"id": "spotify_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
-                            "deezer": {"track": {"id": "deezer_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
-                            "youtube": {"vid": "youtube_vid"},
-                            "musicbrainz": [{"track": {"id": "mb_track_id"}}],
-                        },
+                        "external_metadata": external_metadata,
                     }
                 ]
             },
@@ -167,12 +176,7 @@ def test_identify_audio_includes_streaming_links(monkeypatch, configured_credent
     result = fingerprint.identify_audio(b"audio")
 
     assert result is not None
-    assert result["streaming_links"] == {
-        "spotify": {"track": {"id": "spotify_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
-        "deezer": {"track": {"id": "deezer_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
-        "youtube": {"vid": "youtube_vid"},
-        "musicbrainz": [{"track": {"id": "mb_track_id"}}],
-    }
+    assert result["streaming_links"] == external_metadata
 
 
 def test_identify_audio_returns_none_on_malformed_response(monkeypatch, configured_credentials):

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -152,8 +152,10 @@ def test_identify_audio_includes_streaming_links(monkeypatch, configured_credent
                         "release_date": "",
                         "acrid": "abc123",
                         "external_metadata": {
-                            "spotify": {"track": {"id": "spotify_track_id"}},
-                            "youtube": {"track": {"id": "youtube_video_id"}},
+                            "spotify": {"track": {"id": "spotify_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
+                            "deezer": {"track": {"id": "deezer_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
+                            "youtube": {"vid": "youtube_vid"},
+                            "musicbrainz": [{"track": {"id": "mb_track_id"}}],
                         },
                     }
                 ]
@@ -166,8 +168,10 @@ def test_identify_audio_includes_streaming_links(monkeypatch, configured_credent
 
     assert result is not None
     assert result["streaming_links"] == {
-        "spotify": "spotify_track_id",
-        "youtube": "youtube_video_id",
+        "spotify": {"track": {"id": "spotify_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
+        "deezer": {"track": {"id": "deezer_track_id"}, "artists": [{"id": "artist_id"}], "album": {"id": "album_id"}},
+        "youtube": {"vid": "youtube_vid"},
+        "musicbrainz": [{"track": {"id": "mb_track_id"}}],
     }
 
 


### PR DESCRIPTION
This pull request updates how streaming link metadata is handled and returned by the `identify_audio` function. Instead of extracting only track IDs, the function now returns the full `external_metadata` object as-is, providing richer metadata for each streaming platform. The associated test has also been updated to reflect this change.

**Streaming metadata handling:**

* Updated `identify_audio` in `app/fingerprint.py` to return the complete `external_metadata` dictionary as `streaming_links`, rather than extracting only the track IDs. This allows downstream consumers to access all available platform metadata.

**Testing updates:**

* Modified the test data in `test_identify_audio_includes_streaming_links` to include more comprehensive metadata for each streaming platform, matching the new output structure.
* Updated test assertions to expect the full metadata objects in `streaming_links`, ensuring the test validates the new behavior.