### PR TITLE
feat: start minimised option and tray double-click

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -99,8 +99,20 @@ def _getfloat(cfg: configparser.ConfigParser, section: str, key: str, fallback: 
 
 def _getbool(cfg: configparser.ConfigParser, section: str, key: str, fallback: bool) -> bool:
     """Parse a config value as a boolean, accepting common true/false variants."""
-    raw = cfg.get(section, key, fallback="true" if fallback else "false").strip().lower()
-    return raw in ("1", "true", "yes", "on")
+    try:
+        raw = cfg.get(section, key, fallback=None)
+    except configparser.Error:
+        logger.warning(f"Invalid value for [{section}] {key} — using default ({fallback})")
+        return fallback
+    if raw is None:
+        return fallback
+    raw = raw.strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    logger.warning(f"Invalid value for [{section}] {key}: {raw!r} — using default ({fallback})")
+    return fallback
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────
@@ -248,11 +260,14 @@ def get_smtc_ignored_apps() -> list[str]:
     return [s.strip().lower() for s in raw.split(",") if s.strip()]
 
 
-# ── REST API ──────────────────────────────────────────────────────────────────
+# ── General / UI ─────────────────────────────────────────────────────────────
 
 
 def get_start_minimised() -> bool:
     return _getbool(_cfg(), "general", "start_minimised", False)
+
+
+# ── REST API ──────────────────────────────────────────────────────────────────
 
 
 def get_rest_api_enabled() -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,12 @@ def _getfloat(cfg: configparser.ConfigParser, section: str, key: str, fallback: 
         return fallback
 
 
+def _getbool(cfg: configparser.ConfigParser, section: str, key: str, fallback: bool) -> bool:
+    """Parse a config value as a boolean, accepting common true/false variants."""
+    raw = cfg.get(section, key, fallback="true" if fallback else "false").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 
 
@@ -245,9 +251,12 @@ def get_smtc_ignored_apps() -> list[str]:
 # ── REST API ──────────────────────────────────────────────────────────────────
 
 
+def get_start_minimised() -> bool:
+    return _getbool(_cfg(), "general", "start_minimised", False)
+
+
 def get_rest_api_enabled() -> bool:
-    raw = _cfg().get("rest_api", "enabled", fallback="true").strip().lower()
-    return raw not in ("0", "false", "no", "off")
+    return _getbool(_cfg(), "rest_api", "enabled", True)
 
 
 def get_rest_api_port() -> int:

--- a/app/config.py
+++ b/app/config.py
@@ -98,21 +98,13 @@ def _getfloat(cfg: configparser.ConfigParser, section: str, key: str, fallback: 
 
 
 def _getbool(cfg: configparser.ConfigParser, section: str, key: str, fallback: bool) -> bool:
-    """Parse a config value as a boolean, accepting common true/false variants."""
+    """Parse a config value as a boolean, using fallback silently when absent."""
     try:
+        return cfg.getboolean(section, key, fallback=fallback)
+    except (ValueError, configparser.Error):
         raw = cfg.get(section, key, fallback=None)
-    except configparser.Error:
-        logger.warning(f"Invalid value for [{section}] {key} — using default ({fallback})")
+        logger.warning(f"Invalid value for [{section}] {key}: {raw!r} — using default ({fallback})")
         return fallback
-    if raw is None:
-        return fallback
-    raw = raw.strip().lower()
-    if raw in ("1", "true", "yes", "on"):
-        return True
-    if raw in ("0", "false", "no", "off"):
-        return False
-    logger.warning(f"Invalid value for [{section}] {key}: {raw!r} — using default ({fallback})")
-    return fallback
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────

--- a/app/main.py
+++ b/app/main.py
@@ -159,7 +159,8 @@ def main():
 
     # Wait for window to be ready before showing it
     window._ready.wait(timeout=5)
-    window.show()
+    if not config.get_start_minimised():
+        window.show()
 
     # On first launch (or if credentials were wiped), open Settings immediately
     if not config.is_configured():

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -160,6 +160,46 @@ def test_migrate_skips_when_legacy_url_is_placeholder(tmp_config):
     assert config.get_api_profiles() == {}
 
 
+# ── Boolean helper ───────────────────────────────────────────────────────────
+
+
+def test_getbool_truthy_variants(tmp_config):
+    cfg = config._load()
+    for val in ("1", "true", "yes", "on", "True", "YES", "ON"):
+        config.save({"general": {"start_minimised": val}})
+        cfg = config._load()
+        assert config._getbool(cfg, "general", "start_minimised", False) is True
+
+
+def test_getbool_falsy_variants(tmp_config):
+    for val in ("0", "false", "no", "off", "False", "NO"):
+        config.save({"general": {"start_minimised": val}})
+        cfg = config._load()
+        assert config._getbool(cfg, "general", "start_minimised", True) is False
+
+
+def test_getbool_invalid_value_returns_fallback(tmp_config):
+    config.save({"general": {"start_minimised": "maybe"}})
+    cfg = config._load()
+    assert config._getbool(cfg, "general", "start_minimised", True) is True
+    assert config._getbool(cfg, "general", "start_minimised", False) is False
+
+
+def test_getbool_missing_key_returns_fallback(tmp_config):
+    cfg = config._load()
+    assert config._getbool(cfg, "general", "start_minimised", True) is True
+    assert config._getbool(cfg, "general", "start_minimised", False) is False
+
+
+def test_get_start_minimised_default_false(tmp_config):
+    assert config.get_start_minimised() is False
+
+
+def test_get_start_minimised_reads_config(tmp_config):
+    config.save({"general": {"start_minimised": "true"}})
+    assert config.get_start_minimised() is True
+
+
 # ── Numeric fallbacks ─────────────────────────────────────────────────────────
 
 

--- a/app/ui/settings_window.py
+++ b/app/ui/settings_window.py
@@ -172,6 +172,7 @@ class SettingsWindow:
 
     def _build_general(self, parent):
         self._launch_on_startup = tk.BooleanVar(value=startup.is_enabled())
+        self._start_minimised = tk.BooleanVar(value=config.get_start_minimised())
 
         if sys.platform == "win32":
             tk.Checkbutton(
@@ -194,6 +195,27 @@ class SettingsWindow:
                 "Start Euterpium automatically when you log in to Windows.",
                 dim=True,
             ).pack(anchor="w", padx=(24, 0))
+
+        tk.Checkbutton(
+            parent,
+            text="Start minimised",
+            variable=self._start_minimised,
+            bg=BG_CARD,
+            fg=TEXT,
+            selectcolor=BG_INPUT,
+            activebackground=BG_CARD,
+            activeforeground=TEXT,
+            font=("Segoe UI", 10),
+            relief="flat",
+            bd=0,
+            cursor="hand2",
+        ).pack(anchor="w", pady=(10, 2))
+
+        _styled_label(
+            parent,
+            "Hide the main window on launch — access it via the system tray icon.",
+            dim=True,
+        ).pack(anchor="w", padx=(24, 0))
 
     # ── Credentials tab ───────────────────────────────────────────────────────
 
@@ -657,6 +679,9 @@ class SettingsWindow:
 
         ok = config.save(
             {
+                "general": {
+                    "start_minimised": "true" if self._start_minimised.get() else "false",
+                },
                 "acrcloud": {
                     "host": self._acr_host.get().strip(),
                     "access_key": self._acr_key.get().strip(),

--- a/app/ui/tray.py
+++ b/app/ui/tray.py
@@ -144,7 +144,7 @@ class TrayIcon:
         items.extend(
             [
                 pystray.Menu.SEPARATOR,
-                pystray.MenuItem("Show window", lambda: self.on_show_window()),
+                pystray.MenuItem("Show window", lambda: self.on_show_window(), default=True),
                 pystray.MenuItem("Settings", lambda: self.on_show_settings()),
                 *update_items,
                 pystray.Menu.SEPARATOR,

--- a/app/ui/window.py
+++ b/app/ui/window.py
@@ -77,6 +77,7 @@ class MainWindow:
 
     def run(self):
         self._root = tk.Tk()
+        self._root.withdraw()  # hidden until show() is called
         self._build_ui()
         self._settings_window = SettingsWindow(self._root, on_saved=self._on_settings_saved)
         self._root.protocol("WM_DELETE_WINDOW", self._on_close)


### PR DESCRIPTION
## Summary

- Adds a **Start minimised** checkbox to the General settings tab — hides the main window on launch, useful when paired with Launch on startup
- **Double-clicking** the system tray icon now opens the main window (pystray `default=True` on the Show window menu item)
- Extracts a `_getbool()` config helper parallel to the existing `_getint`/`_getfloat`, replacing the inconsistent whitelist/blacklist boolean parsing in `get_rest_api_enabled()`

## Test plan

- [ ] Launch app normally — window appears as before
- [ ] Enable Start minimised, restart — window stays hidden, tray icon present
- [ ] Double-click tray icon — main window opens
- [ ] Single-click tray → Show window — main window opens
- [ ] Disable Start minimised, restart — window appears again
- [ ] REST API enable/disable still works correctly (exercises `_getbool` with `True` default)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)