### PR TITLE
fix: notification app label shows 'Python' instead of 'Euterpium'

### DIFF
--- a/app/startup.py
+++ b/app/startup.py
@@ -12,10 +12,12 @@
 import logging
 import sys
 
+from version import APP_DISPLAY_NAME
+
 logger = logging.getLogger(__name__)
 
 _REG_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
-_REG_VALUE = "Euterpium"
+_REG_VALUE = APP_DISPLAY_NAME
 
 
 def _exe_path() -> str:

--- a/app/ui/notifications.py
+++ b/app/ui/notifications.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+from version import APP_DISPLAY_NAME
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -49,7 +51,7 @@ def notify_track(track: dict, game: dict | None = None):
     icon = _ICON_PATH if os.path.exists(_ICON_PATH) else None
 
     try:
-        kwargs = dict(title=heading, body=body)
+        kwargs = dict(app_id=APP_DISPLAY_NAME, title=heading, body=body)
         if icon:
             kwargs["icon"] = icon
         _notify(**kwargs)
@@ -67,7 +69,8 @@ def notify_update_available(version: str):
 
     try:
         kwargs = {
-            "title": "Euterpium update available",
+            "app_id": APP_DISPLAY_NAME,
+            "title": f"{APP_DISPLAY_NAME} update available",
             "body": f"Version {version} is ready to install from GitHub Releases.",
         }
         if icon:

--- a/app/ui/settings_window.py
+++ b/app/ui/settings_window.py
@@ -9,6 +9,7 @@ from tkinter import messagebox, ttk
 
 import config
 import startup
+from version import APP_DISPLAY_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class SettingsWindow:
 
     def _build(self):
         win = tk.Toplevel(self._parent)
-        win.title("Euterpium — Settings")
+        win.title(f"{APP_DISPLAY_NAME} — Settings")
         win.configure(bg=BG)
         win.resizable(True, True)
         win.minsize(460, 400)

--- a/app/ui/tray.py
+++ b/app/ui/tray.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw
 
+from version import APP_DISPLAY_NAME
+
 if TYPE_CHECKING:
     from updater import AvailableUpdate
 
@@ -121,7 +123,9 @@ class TrayIcon:
         if self._current_version:
             items.extend(
                 [
-                    pystray.MenuItem(f"Euterpium {self._current_version}", None, enabled=False),
+                    pystray.MenuItem(
+                        f"{APP_DISPLAY_NAME} {self._current_version}", None, enabled=False
+                    ),
                 ]
             )
 
@@ -188,7 +192,7 @@ class TrayIcon:
         self._icon = pystray.Icon(
             name="euterpium",
             icon=self._icon_default,
-            title="Euterpium — Nothing playing",
+            title=f"{APP_DISPLAY_NAME} — Nothing playing",
             menu=self._build_menu(),
         )
         self._icon.run()

--- a/app/version.py
+++ b/app/version.py
@@ -43,6 +43,8 @@ def _compute_display_version(version_str: str) -> str:
         return _detect_git_branch() or "dev"
 
 
+APP_DISPLAY_NAME = "Euterpium"
+
 DEV_VERSION = "0.1.0"
 # Keep this as a quoted string literal so the release workflow can replace it.
 __version__ = "0.1.0"


### PR DESCRIPTION
Fixes #65

## Summary

- Adds `APP_DISPLAY_NAME = "Euterpium"` constant to `version.py`
- Passes `app_id=APP_DISPLAY_NAME` to `win11toast` so notifications show "Euterpium" as the sender instead of "Python"
- Uses the constant in `startup.py` (registry value), `tray.py` (menu item + tooltip), and `settings_window.py` (window title)

## Test plan

- [ ] Trigger a track notification — sender label shows "Euterpium"
- [ ] Trigger an update notification — sender label shows "Euterpium"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)