### PR TITLE
feat: display changelog in installer wizard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,11 +129,9 @@ jobs:
             -f tag_name=$env:RELEASE_TAG `
             -f target_commitish=main `
             --jq '.body'
-          $changelogMd = "app\dist\changelog.md"
-          $changelogRtf = "app\dist\changelog.rtf"
           New-Item -ItemType Directory -Force -Path app\dist | Out-Null
-          Set-Content -Path $changelogMd -Value $notes -Encoding UTF8
-          pandoc -f markdown -t rtf -o $changelogRtf $changelogMd
+          $changelogRtf = "$PWD\app\dist\changelog.rtf"
+          $notes | pandoc -f markdown -t rtf -o $changelogRtf
           echo "CHANGELOG_RTF=$changelogRtf" >> $env:GITHUB_ENV
 
       - name: Build installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,22 @@ jobs:
       - name: Install Inno Setup (pinned)
         run: choco install innosetup --version=6.7.1 --allow-downgrade --no-progress -y
 
+      - name: Generate changelog for installer
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $notes = gh api --method POST repos/aquarion/euterpium/releases/generate-notes `
+            -f tag_name=$env:RELEASE_TAG `
+            -f target_commitish=main `
+            --jq '.body'
+          $changelogMd = "app\dist\changelog.md"
+          $changelogRtf = "app\dist\changelog.rtf"
+          New-Item -ItemType Directory -Force -Path app\dist | Out-Null
+          Set-Content -Path $changelogMd -Value $notes -Encoding UTF8
+          pandoc -f markdown -t rtf -o $changelogRtf $changelogMd
+          echo "CHANGELOG_RTF=$changelogRtf" >> $env:GITHUB_ENV
+
       - name: Build installer
         shell: pwsh
         run: |
@@ -131,7 +147,7 @@ jobs:
           if (-not $iscc) {
             throw "ISCC.exe not found in expected locations"
           }
-          & $iscc "/DAppVersion=$env:APP_VERSION" "/DReleaseTag=$env:RELEASE_TAG" app\euterpium.iss
+          & $iscc "/DAppVersion=$env:APP_VERSION" "/DReleaseTag=$env:RELEASE_TAG" "/DChangelogFile=$env:CHANGELOG_RTF" app\euterpium.iss
 
       - name: Zip the build
         run: |

--- a/app/euterpium.iss
+++ b/app/euterpium.iss
@@ -10,6 +10,9 @@
 AppId={{B2C48E1C-6E56-4FE9-B1EF-47A643FE53D4}}
 AppName={#MyAppName}
 AppVersion={#AppVersion}
+#ifdef ChangelogFile
+InfoBeforeFile={#ChangelogFile}
+#endif
 AppPublisher=aquarion
 DefaultDirName={localappdata}\Programs\Euterpium
 DefaultGroupName={#MyAppName}


### PR DESCRIPTION
Fixes #66

## Summary

- Adds a pre-installation changelog page to the Inno Setup wizard using `InfoBeforeFile`
- Release workflow generates notes via the GitHub API (`releases/generate-notes`), converts from markdown to RTF using `pandoc`, and passes the file to ISCC via `/DChangelogFile`
- Conditional `#ifdef` in the `.iss` so local/manual builds without the define still work

## Test plan

- [ ] Trigger a release build and verify the installer shows a formatted "What's New" page before the install step

🤖 Generated with [Claude Code](https://claude.ai/claude-code)