### PR TITLE
fix: install pandoc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Install Inno Setup (pinned)
         run: choco install innosetup --version=6.7.1 --allow-downgrade --no-progress -y
 
+      - name: Install pandoc
+        run: choco install pandoc --no-progress -y
+
       - name: Generate changelog for installer
         shell: pwsh
         env:


### PR DESCRIPTION
## Summary

- `pandoc` is not pre-installed on `windows-latest`; the "Generate changelog for installer" step was failing with "term 'pandoc' is not recognized"
- Adds a `choco install pandoc` step immediately before it

## Test plan

- [ ] Trigger a release and verify the changelog RTF is generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)