### PR TITLE
fix: switch release-changelog trigger to workflow_run

### DIFF
--- a/.github/workflows/release-changelog.lock.yml
+++ b/.github/workflows/release-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fcde0928b2db199c9b9681fb58d83e1a37c4fed172a1808114170b511c4ccccc","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f046fd4388df717f0f2463fdd5853585cbffb717876cd6006784b77dd2585a71","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _
 #   / _ \                 | | (_)
@@ -47,9 +47,6 @@
 
 name: "Release Changelog"
 "on":
-  release:
-    types:
-    - published
   workflow_dispatch:
     inputs:
       aw_context:
@@ -60,6 +57,12 @@ name: "Release Changelog"
       tag:
         description: Release tag to generate highlights for (e.g. v2.3.0)
         required: true
+  workflow_run:
+    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
+    types:
+    - completed
+    workflows:
+    - Release
 
 permissions: {}
 
@@ -71,7 +74,10 @@ run-name: "Release Changelog"
 jobs:
   activation:
     needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
+    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
+    if: >
+      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
+      (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -170,14 +176,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_12b0cbc8a00aff20_EOF'
+          cat << 'GH_AW_PROMPT_20ad72a42f2ca70a_EOF'
           <system>
-          GH_AW_PROMPT_12b0cbc8a00aff20_EOF
+          GH_AW_PROMPT_20ad72a42f2ca70a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_12b0cbc8a00aff20_EOF'
+          cat << 'GH_AW_PROMPT_20ad72a42f2ca70a_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -209,12 +215,12 @@ jobs:
           {{/if}}
           </github-context>
 
-          GH_AW_PROMPT_12b0cbc8a00aff20_EOF
+          GH_AW_PROMPT_20ad72a42f2ca70a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_12b0cbc8a00aff20_EOF'
+          cat << 'GH_AW_PROMPT_20ad72a42f2ca70a_EOF'
           </system>
           {{#runtime-import .github/workflows/release-changelog.md}}
-          GH_AW_PROMPT_12b0cbc8a00aff20_EOF
+          GH_AW_PROMPT_20ad72a42f2ca70a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -386,9 +392,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_155f40a3d4400607_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1aab50109eaf556d_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_155f40a3d4400607_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_1aab50109eaf556d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -575,7 +581,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
 
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_dd20f9d5492dad1a_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_eacfefb7bf50921b_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -616,7 +622,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dd20f9d5492dad1a_EOF
+          GH_AW_MCP_CONFIG_eacfefb7bf50921b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release-changelog.md
+++ b/.github/workflows/release-changelog.md
@@ -2,8 +2,9 @@
 name: Release Changelog
 description: Generate structured release highlights for a published Euterpium release using merged PRs and commits since the previous release.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -42,7 +43,7 @@ The project uses conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.) 
 
 1. Determine the current release tag:
    - If triggered by `workflow_dispatch`, use the provided `tag` input.
-   - If triggered by the `release` event, use the tag from the triggering release.
+   - If triggered by `workflow_run`, find the most recently published (non-draft) release in this repository.
 2. Identify the previous release tag.
 3. Fetch all pull requests merged between the previous release and the current release (by merge date or commit range).
 4. Read each PR's title and body to understand what changed.


### PR DESCRIPTION
## Summary

- `release: [published]` doesn't fire when a release is published via `GITHUB_TOKEN` — GitHub blocks it to prevent recursive workflow loops
- Switch to `workflow_run: workflows: ["Release"]` which fires unconditionally after the Release workflow completes
- Update agent instructions to find the most recently published release when triggered by `workflow_run`

## Test plan

- [ ] Trigger a release and verify the Release Changelog workflow appears in Actions and updates the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)