### PR TITLE
fix: add --standalone to pandoc RTF generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
             --jq '.body'
           New-Item -ItemType Directory -Force -Path app\dist | Out-Null
           $changelogRtf = "$PWD\app\dist\changelog.rtf"
-          $notes | pandoc -f markdown -t rtf -o $changelogRtf
+          $notes | pandoc -f markdown -t rtf --standalone -o $changelogRtf
           echo "CHANGELOG_RTF=$changelogRtf" >> $env:GITHUB_ENV
 
       - name: Build installer


### PR DESCRIPTION
## Summary

- Without `--standalone`, pandoc outputs an RTF fragment (no `{\rtf1\ansi...}` header)
- Inno Setup's RichEdit control was displaying raw RTF markup instead of rendering it
- Adding `--standalone` produces a complete RTF document

## Test plan

- [ ] Trigger a release and verify the installer info screen renders formatted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)