### PR TITLE
feat: ACRCloud language preference with Windows locale auto-detection

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -168,8 +168,9 @@ def get_acrcloud_language() -> str:
 
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as key:
             value, _ = winreg.QueryValueEx(key, "LocaleName")
-            return value.strip() if value.strip() else "en"
-    except Exception:
+            stripped = value.strip()
+            return stripped if stripped else "en"
+    except (ImportError, OSError):
         return "en"
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -155,6 +155,24 @@ def get_acrcloud_access_secret() -> str:
     return _cfg().get("acrcloud", "access_secret", fallback="")
 
 
+def get_acrcloud_language() -> str:
+    """Returns the preferred language code for ACRCloud results.
+
+    Priority: [acrcloud] language in INI → Windows locale → 'en'.
+    """
+    explicit = _cfg().get("acrcloud", "language", fallback="").strip()
+    if explicit:
+        return explicit
+    try:
+        import winreg
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as key:
+            value, _ = winreg.QueryValueEx(key, "LocaleName")
+            return value.strip() if value.strip() else "en"
+    except Exception:
+        return "en"
+
+
 # ── Your API ──────────────────────────────────────────────────────────────────
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -168,6 +168,8 @@ def get_acrcloud_language() -> str:
 
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as key:
             value, _ = winreg.QueryValueEx(key, "LocaleName")
+            if not isinstance(value, str):
+                return "en"
             stripped = value.strip()
             return stripped if stripped else "en"
     except (ImportError, OSError):

--- a/app/euterpium.ini
+++ b/app/euterpium.ini
@@ -3,9 +3,12 @@
 level = INFO
 
 [acrcloud]
-host        = identify-eu-west-1.acrcloud.com
-access_key  =
+host          = identify-eu-west-1.acrcloud.com
+access_key    =
 access_secret =
+; Preferred language for track/artist/album names returned by ACRCloud.
+; Leave blank to auto-detect from Windows locale. Examples: en, ja, zh-Hans
+; language =
 
 [api]
 active = dev

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -62,6 +62,20 @@ def _preferred_script(lang_code: str) -> str:
     return "latin"
 
 
+def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
+    if not langs or not preferred:
+        return primary
+    candidate = preferred
+    while candidate:
+        for entry in langs:
+            if entry.get("code", "").lower() == candidate.lower():
+                return entry["name"]
+        if "-" not in candidate:
+            break
+        candidate = candidate.rsplit("-", 1)[0]
+    return primary
+
+
 def identify_audio(wav_bytes: bytes) -> dict | None:
     """
     Sends WAV audio bytes to ACRCloud for identification.

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -150,14 +150,14 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         preferred_script = _preferred_script(preferred_lang)
 
         def _artist_str(entry: dict) -> str:
-            return ", ".join(a["name"] for a in entry.get("artists", []))
+            return ", ".join(a.get("name", "") for a in entry.get("artists", []))
 
         title = _pick_lang(music.get("title", ""), music.get("langs", []), preferred_lang)
         if _dominant_script(title) != preferred_script:
             title = _pick_field(music_list, lambda e: e.get("title", ""), preferred_script)
 
         artist = ", ".join(
-            _pick_lang(a["name"], a.get("langs", []), preferred_lang)
+            _pick_lang(a.get("name", ""), a.get("langs", []), preferred_lang)
             for a in music.get("artists", [])
         )
         if _dominant_script(artist) != preferred_script:

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -69,7 +69,9 @@ def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
     while candidate:
         for entry in langs:
             if entry.get("code", "").lower() == candidate.lower():
-                return entry["name"]
+                name = entry.get("name")
+                if name:
+                    return name
         if "-" not in candidate:
             break
         candidate = candidate.rsplit("-", 1)[0]

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -62,20 +62,20 @@ def _preferred_script(lang_code: str) -> str:
     return "latin"
 
 
-def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
+def _pick_lang(primary: str, langs: list[dict], preferred: str) -> tuple[str, bool]:
     if not langs or not preferred:
-        return primary
+        return primary, False
     candidate = preferred
     while candidate:
         for entry in langs:
             if entry.get("code", "").lower() == candidate.lower():
                 name = entry.get("name")
                 if name:
-                    return name
+                    return name, True
         if "-" not in candidate:
             break
         candidate = candidate.rsplit("-", 1)[0]
-    return primary
+    return primary, False
 
 
 def _pick_field(entries: list[dict], field_fn, preferred_script: str) -> str:
@@ -152,20 +152,26 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         def _artist_str(entry: dict) -> str:
             return ", ".join(a.get("name", "") for a in entry.get("artists", []))
 
-        title = _pick_lang(music.get("title", ""), music.get("langs", []), preferred_lang)
-        if _dominant_script(title) != preferred_script:
+        title, title_matched = _pick_lang(
+            music.get("title", ""), music.get("langs", []), preferred_lang
+        )
+        if not title_matched and _dominant_script(title) != preferred_script:
             title = _pick_field(music_list, lambda e: e.get("title", ""), preferred_script)
 
-        artist = ", ".join(
+        artist_results = [
             _pick_lang(a.get("name", ""), a.get("langs", []), preferred_lang)
             for a in music.get("artists", [])
-        )
-        if _dominant_script(artist) != preferred_script:
+        ]
+        artist = ", ".join(value for value, _ in artist_results)
+        all_artists_matched = bool(artist_results) and all(matched for _, matched in artist_results)
+        if not all_artists_matched and _dominant_script(artist) != preferred_script:
             artist = _pick_field(music_list, _artist_str, preferred_script)
 
         album_info = music.get("album", {})
-        album = _pick_lang(album_info.get("name", ""), album_info.get("langs", []), preferred_lang)
-        if _dominant_script(album) != preferred_script:
+        album, album_matched = _pick_lang(
+            album_info.get("name", ""), album_info.get("langs", []), preferred_lang
+        )
+        if not album_matched and _dominant_script(album) != preferred_script:
             album = _pick_field(
                 music_list, lambda e: e.get("album", {}).get("name", ""), preferred_script
             )

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -76,6 +76,14 @@ def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
     return primary
 
 
+def _pick_field(entries: list[dict], field_fn, preferred_script: str) -> str:
+    for entry in entries:
+        value = field_fn(entry)
+        if value and _dominant_script(value) == preferred_script:
+            return value
+    return field_fn(entries[0])
+
+
 def identify_audio(wav_bytes: bytes) -> dict | None:
     """
     Sends WAV audio bytes to ACRCloud for identification.

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -163,8 +163,11 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
             for a in music.get("artists", [])
         ]
         artist = ", ".join(value for value, _ in artist_results if value)
-        all_artists_matched = bool(artist_results) and all(matched for _, matched in artist_results)
-        if not all_artists_matched and _dominant_script(artist) != preferred_script:
+        # any (not all): if any artist had a langs match, preserve those
+        # localized names rather than letting _pick_field replace the joined
+        # string with a different music[] entry.
+        any_artist_matched = any(matched for _, matched in artist_results)
+        if not any_artist_matched and _dominant_script(artist) != preferred_script:
             artist = _pick_field(music_list, _artist_str, preferred_script)
 
         album_info = music.get("album", {})

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -47,6 +47,21 @@ def _dominant_script(text: str) -> str:
     return max(counts, key=counts.get)
 
 
+_SCRIPT_PREFIXES: dict[str, tuple[str, ...]] = {
+    "cjk": ("ja", "zh"),
+    "hangul": ("ko",),
+    "cyrillic": ("ru", "uk", "bg", "sr", "be"),
+}
+
+
+def _preferred_script(lang_code: str) -> str:
+    lower = lang_code.lower()
+    for script, prefixes in _SCRIPT_PREFIXES.items():
+        if any(lower == p or lower.startswith(p + "-") for p in prefixes):
+            return script
+    return "latin"
+
+
 def identify_audio(wav_bytes: bytes) -> dict | None:
     """
     Sends WAV audio bytes to ACRCloud for identification.

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -30,6 +30,23 @@ def _build_signature(timestamp: str, access_key: str, access_secret: str) -> str
     return base64.b64encode(signature.digest()).decode("utf-8")
 
 
+def _dominant_script(text: str) -> str:
+    counts: dict[str, int] = {"latin": 0, "cjk": 0, "hangul": 0, "cyrillic": 0}
+    for ch in text:
+        cp = ord(ch)
+        if 0x0041 <= cp <= 0x024F:
+            counts["latin"] += 1
+        elif 0x3040 <= cp <= 0x30FF or 0x3400 <= cp <= 0x4DBF or 0x4E00 <= cp <= 0x9FFF:
+            counts["cjk"] += 1
+        elif 0x1100 <= cp <= 0x11FF or 0xAC00 <= cp <= 0xD7AF:
+            counts["hangul"] += 1
+        elif 0x0400 <= cp <= 0x04FF:
+            counts["cyrillic"] += 1
+    if not any(counts.values()):
+        return "unknown"
+    return max(counts, key=counts.get)
+
+
 def identify_audio(wav_bytes: bytes) -> dict | None:
     """
     Sends WAV audio bytes to ACRCloud for identification.

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -143,15 +143,38 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         return None
 
     try:
-        music = result["metadata"]["music"][0]
-        artists = ", ".join(a["name"] for a in music.get("artists", []))
+        music_list = result["metadata"]["music"]
+        music = music_list[0]
+
+        preferred_lang = config.get_acrcloud_language()
+        preferred_script = _preferred_script(preferred_lang)
+
+        def _artist_str(entry: dict) -> str:
+            return ", ".join(a["name"] for a in entry.get("artists", []))
+
+        title = _pick_lang(music.get("title", ""), music.get("langs", []), preferred_lang)
+        if _dominant_script(title) != preferred_script:
+            title = _pick_field(music_list, lambda e: e.get("title", ""), preferred_script)
+
+        artist = ", ".join(
+            _pick_lang(a["name"], a.get("langs", []), preferred_lang)
+            for a in music.get("artists", [])
+        )
+        if _dominant_script(artist) != preferred_script:
+            artist = _pick_field(music_list, _artist_str, preferred_script)
+
         album_info = music.get("album", {})
+        album = _pick_lang(album_info.get("name", ""), album_info.get("langs", []), preferred_lang)
+        if _dominant_script(album) != preferred_script:
+            album = _pick_field(
+                music_list, lambda e: e.get("album", {}).get("name", ""), preferred_script
+            )
 
         return {
             "source": "acrcloud",
-            "title": music.get("title", ""),
-            "artist": artists,
-            "album": album_info.get("name", ""),
+            "title": title,
+            "artist": artist,
+            "album": album,
             "release_date": music.get("release_date", ""),
             "acrid": music.get("acrid", ""),
             "streaming_links": music.get("external_metadata", {}),

--- a/app/fingerprint.py
+++ b/app/fingerprint.py
@@ -150,7 +150,7 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         preferred_script = _preferred_script(preferred_lang)
 
         def _artist_str(entry: dict) -> str:
-            return ", ".join(a.get("name", "") for a in entry.get("artists", []))
+            return ", ".join(name for a in entry.get("artists", []) if (name := a.get("name", "")))
 
         title, title_matched = _pick_lang(
             music.get("title", ""), music.get("langs", []), preferred_lang
@@ -162,7 +162,7 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
             _pick_lang(a.get("name", ""), a.get("langs", []), preferred_lang)
             for a in music.get("artists", [])
         ]
-        artist = ", ".join(value for value, _ in artist_results)
+        artist = ", ".join(value for value, _ in artist_results if value)
         all_artists_matched = bool(artist_results) and all(matched for _, matched in artist_results)
         if not all_artists_matched and _dominant_script(artist) != preferred_script:
             artist = _pick_field(music_list, _artist_str, preferred_script)

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -1,6 +1,8 @@
 # tests/test_config.py — config read/write, profiles, migration, validation
 
 import logging
+import sys
+import types
 
 import pytest
 
@@ -317,3 +319,40 @@ def test_spectral_config_round_trip(tmp_config):
     assert config.get_spectral_flatness_threshold() == pytest.approx(0.5)
     assert config.get_fingerprint_bands() == 16
     assert config.get_fingerprint_change_threshold() == pytest.approx(0.4)
+
+
+# ── ACRCloud language ──────────────────────────────────────────────────────────
+
+
+def test_get_acrcloud_language_explicit_ini(tmp_config):
+    config.save({"acrcloud": {"language": "ja"}})
+    assert config.get_acrcloud_language() == "ja"
+
+
+def test_get_acrcloud_language_from_registry(tmp_config, monkeypatch):
+    fake_winreg = types.ModuleType("winreg")
+    fake_winreg.HKEY_CURRENT_USER = 0
+
+    class _FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    fake_winreg.OpenKey = lambda *a: _FakeKey()
+    fake_winreg.QueryValueEx = lambda key, name: ("en-GB", 1)
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    assert config.get_acrcloud_language() == "en-GB"
+
+
+def test_get_acrcloud_language_registry_error_returns_en(tmp_config, monkeypatch):
+    fake_winreg = types.ModuleType("winreg")
+    fake_winreg.HKEY_CURRENT_USER = 0
+
+    def _raise(*a):
+        raise OSError("no registry")
+
+    fake_winreg.OpenKey = _raise
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    assert config.get_acrcloud_language() == "en"

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -356,3 +356,20 @@ def test_get_acrcloud_language_registry_error_returns_en(tmp_config, monkeypatch
     fake_winreg.OpenKey = _raise
     monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
     assert config.get_acrcloud_language() == "en"
+
+
+def test_get_acrcloud_language_non_string_registry_value_returns_en(tmp_config, monkeypatch):
+    fake_winreg = types.ModuleType("winreg")
+    fake_winreg.HKEY_CURRENT_USER = 0
+
+    class _FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    fake_winreg.OpenKey = lambda *a: _FakeKey()
+    fake_winreg.QueryValueEx = lambda key, name: (None, 1)
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    assert config.get_acrcloud_language() == "en"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -72,6 +72,7 @@ def configured_credentials(monkeypatch):
     monkeypatch.setattr(fingerprint.config, "get_acrcloud_access_secret", lambda: "mysecret")
     monkeypatch.setattr(fingerprint.config, "get_acrcloud_host", lambda: "identify.acrcloud.com")
     monkeypatch.setattr(fingerprint.time, "time", lambda: 1700000000)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
 
 
 def _make_response(json_data, status_code=200):

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -509,3 +509,28 @@ def test_identify_audio_skips_script_scan_when_langs_matches(monkeypatch, config
     result = fingerprint.identify_audio(b"audio")
     # Title from langs match wins, even though it's CJK and preferred is en/latin.
     assert result["title"] == "你好"
+
+
+def test_identify_audio_filters_empty_artist_names(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "Song",
+                        "artists": [{}, {"name": "Real Artist"}, {"name": ""}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["artist"] == "Real Artist"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -281,41 +281,48 @@ def test_preferred_script_empty_string_defaults_to_latin():
 
 def test_pick_lang_exact_match():
     langs = [{"code": "zh-Hans", "name": "你好"}]
-    assert _pick_lang("Hello", langs, "zh-Hans") == "你好"
+    assert _pick_lang("Hello", langs, "zh-Hans") == ("你好", True)
 
 
 def test_pick_lang_prefix_match_strips_region():
     langs = [{"code": "en", "name": "Hello"}]
-    assert _pick_lang("Hola", langs, "en-GB") == "Hello"
+    assert _pick_lang("Hola", langs, "en-GB") == ("Hello", True)
 
 
 def test_pick_lang_multi_level_strip():
     langs = [{"code": "zh-Hans", "name": "你好"}]
-    assert _pick_lang("Hello", langs, "zh-Hans-CN") == "你好"
+    assert _pick_lang("Hello", langs, "zh-Hans-CN") == ("你好", True)
 
 
 def test_pick_lang_no_match_returns_primary():
     langs = [{"code": "ja", "name": "こんにちは"}]
-    assert _pick_lang("Hello", langs, "en") == "Hello"
+    assert _pick_lang("Hello", langs, "en") == ("Hello", False)
 
 
 def test_pick_lang_empty_langs_returns_primary():
-    assert _pick_lang("Hello", [], "en") == "Hello"
+    assert _pick_lang("Hello", [], "en") == ("Hello", False)
 
 
 def test_pick_lang_empty_preferred_returns_primary():
     langs = [{"code": "en", "name": "Hello"}]
-    assert _pick_lang("Hola", langs, "") == "Hola"
+    assert _pick_lang("Hola", langs, "") == ("Hola", False)
 
 
 def test_pick_lang_skips_entry_with_missing_name():
     langs = [{"code": "en"}, {"code": "en", "name": "Hello"}]
-    assert _pick_lang("Hola", langs, "en") == "Hello"
+    assert _pick_lang("Hola", langs, "en") == ("Hello", True)
 
 
 def test_pick_lang_falls_back_when_only_match_has_missing_name():
     langs = [{"code": "en"}]
-    assert _pick_lang("Hola", langs, "en") == "Hola"
+    assert _pick_lang("Hola", langs, "en") == ("Hola", False)
+
+
+def test_pick_lang_match_takes_priority_over_script():
+    # langs entry tagged "en" but content is CJK — should still be returned because
+    # the langs match takes priority over script scanning per the spec.
+    langs = [{"code": "en", "name": "你好"}]
+    assert _pick_lang("Hola", langs, "en") == ("你好", True)
 
 
 # ── _pick_field ───────────────────────────────────────────────────────────────
@@ -465,3 +472,40 @@ def test_identify_audio_langs_title_and_script_scan_artist(monkeypatch, configur
     result = fingerprint.identify_audio(b"audio")
     assert result["title"] == "Hello"
     assert result["artist"] == "Masayoshi Soken"
+
+
+def test_identify_audio_skips_script_scan_when_langs_matches(monkeypatch, configured_credentials):
+    # Even when the langs match returns content in the "wrong" script,
+    # the script-scan pass must be skipped because the langs pass took priority.
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "Hola",
+                        "langs": [{"code": "en", "name": "你好"}],
+                        "artists": [{"name": "Artist"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "English Title",
+                        "artists": [{"name": "Artist"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    # Title from langs match wins, even though it's CJK and preferred is en/latin.
+    assert result["title"] == "你好"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -307,6 +307,16 @@ def test_pick_lang_empty_preferred_returns_primary():
     assert _pick_lang("Hola", langs, "") == "Hola"
 
 
+def test_pick_lang_skips_entry_with_missing_name():
+    langs = [{"code": "en"}, {"code": "en", "name": "Hello"}]
+    assert _pick_lang("Hola", langs, "en") == "Hello"
+
+
+def test_pick_lang_falls_back_when_only_match_has_missing_name():
+    langs = [{"code": "en"}]
+    assert _pick_lang("Hola", langs, "en") == "Hola"
+
+
 # ── _pick_field ───────────────────────────────────────────────────────────────
 
 

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -7,7 +7,7 @@ import hmac
 import pytest
 
 import fingerprint
-from fingerprint import _build_signature, _dominant_script
+from fingerprint import _build_signature, _dominant_script, _preferred_script
 
 # ── Signature generation ──────────────────────────────────────────────────────
 
@@ -228,3 +228,42 @@ def test_dominant_script_unknown_for_punctuation():
 
 def test_dominant_script_empty_string():
     assert _dominant_script("") == "unknown"
+
+
+# ── _preferred_script ─────────────────────────────────────────────────────────
+
+
+def test_preferred_script_en_is_latin():
+    assert _preferred_script("en") == "latin"
+
+
+def test_preferred_script_en_gb_is_latin():
+    assert _preferred_script("en-GB") == "latin"
+
+
+def test_preferred_script_ja_is_cjk():
+    assert _preferred_script("ja") == "cjk"
+
+
+def test_preferred_script_zh_hans_is_cjk():
+    assert _preferred_script("zh-Hans") == "cjk"
+
+
+def test_preferred_script_zh_hans_cn_is_cjk():
+    assert _preferred_script("zh-Hans-CN") == "cjk"
+
+
+def test_preferred_script_ko_is_hangul():
+    assert _preferred_script("ko") == "hangul"
+
+
+def test_preferred_script_ru_is_cyrillic():
+    assert _preferred_script("ru") == "cyrillic"
+
+
+def test_preferred_script_unknown_code_defaults_to_latin():
+    assert _preferred_script("xx-Unknown") == "latin"
+
+
+def test_preferred_script_empty_string_defaults_to_latin():
+    assert _preferred_script("") == "latin"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -7,7 +7,7 @@ import hmac
 import pytest
 
 import fingerprint
-from fingerprint import _build_signature, _dominant_script, _preferred_script
+from fingerprint import _build_signature, _dominant_script, _pick_lang, _preferred_script
 
 # ── Signature generation ──────────────────────────────────────────────────────
 
@@ -267,3 +267,35 @@ def test_preferred_script_unknown_code_defaults_to_latin():
 
 def test_preferred_script_empty_string_defaults_to_latin():
     assert _preferred_script("") == "latin"
+
+
+# ── _pick_lang ────────────────────────────────────────────────────────────────
+
+
+def test_pick_lang_exact_match():
+    langs = [{"code": "zh-Hans", "name": "你好"}]
+    assert _pick_lang("Hello", langs, "zh-Hans") == "你好"
+
+
+def test_pick_lang_prefix_match_strips_region():
+    langs = [{"code": "en", "name": "Hello"}]
+    assert _pick_lang("Hola", langs, "en-GB") == "Hello"
+
+
+def test_pick_lang_multi_level_strip():
+    langs = [{"code": "zh-Hans", "name": "你好"}]
+    assert _pick_lang("Hello", langs, "zh-Hans-CN") == "你好"
+
+
+def test_pick_lang_no_match_returns_primary():
+    langs = [{"code": "ja", "name": "こんにちは"}]
+    assert _pick_lang("Hello", langs, "en") == "Hello"
+
+
+def test_pick_lang_empty_langs_returns_primary():
+    assert _pick_lang("Hello", [], "en") == "Hello"
+
+
+def test_pick_lang_empty_preferred_returns_primary():
+    langs = [{"code": "en", "name": "Hello"}]
+    assert _pick_lang("Hola", langs, "") == "Hola"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -342,3 +342,125 @@ def test_pick_field_returns_first_when_it_already_matches():
         {"title": "祖堅正慶"},
     ]
     assert _pick_field(entries, lambda e: e["title"], "latin") == "Masayoshi Soken"
+
+
+# ── identify_audio — language selection ──────────────────────────────────────
+
+
+def test_identify_audio_picks_title_from_langs(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "你好",
+                        "langs": [{"code": "en", "name": "Hello"}],
+                        "artists": [{"name": "Artist"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["title"] == "Hello"
+
+
+def test_identify_audio_picks_artist_by_script_scan(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "The Aetherial Sea",
+                        "artists": [{"name": "祖堅正慶"}],
+                        "album": {"name": "ENDWALKER: FINAL FANTASY XIV Original Soundtrack"},
+                        "release_date": "2022-02-23",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "The Aetherial Sea",
+                        "artists": [{"name": "Masayoshi Soken"}],
+                        "album": {"name": "ENDWALKER: FINAL FANTASY XIV Original Soundtrack"},
+                        "release_date": "2022-02-23",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["artist"] == "Masayoshi Soken"
+
+
+def test_identify_audio_script_scan_falls_back_to_first_entry(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "曲名",
+                        "artists": [{"name": "アーティスト"}],
+                        "album": {"name": "アルバム"},
+                        "release_date": "",
+                        "acrid": "abc",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["artist"] == "アーティスト"
+
+
+def test_identify_audio_langs_title_and_script_scan_artist(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "你好",
+                        "langs": [{"code": "en", "name": "Hello"}],
+                        "artists": [{"name": "祖堅正慶"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "你好",
+                        "artists": [{"name": "Masayoshi Soken"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["title"] == "Hello"
+    assert result["artist"] == "Masayoshi Soken"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -534,3 +534,43 @@ def test_identify_audio_filters_empty_artist_names(monkeypatch, configured_crede
 
     result = fingerprint.identify_audio(b"audio")
     assert result["artist"] == "Real Artist"
+
+
+def test_identify_audio_keeps_partial_artist_langs_match(monkeypatch, configured_credentials):
+    # When at least one artist has a langs match, the script-scan fallback
+    # must not run — otherwise it would discard the localized name.
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "Song",
+                        "artists": [
+                            {"name": "Primary", "langs": [{"code": "en", "name": "Localized"}]},
+                            {"name": "祖堅正慶"},
+                        ],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "Song",
+                        "artists": [{"name": "Other Latin Artist"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    # The langs match for the first artist must be preserved — the script-scan
+    # fallback must not replace the joined string with music[1]'s artist.
+    assert result["artist"] == "Localized, 祖堅正慶"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -7,7 +7,13 @@ import hmac
 import pytest
 
 import fingerprint
-from fingerprint import _build_signature, _dominant_script, _pick_lang, _preferred_script
+from fingerprint import (
+    _build_signature,
+    _dominant_script,
+    _pick_field,
+    _pick_lang,
+    _preferred_script,
+)
 
 # ── Signature generation ──────────────────────────────────────────────────────
 
@@ -299,3 +305,30 @@ def test_pick_lang_empty_langs_returns_primary():
 def test_pick_lang_empty_preferred_returns_primary():
     langs = [{"code": "en", "name": "Hello"}]
     assert _pick_lang("Hola", langs, "") == "Hola"
+
+
+# ── _pick_field ───────────────────────────────────────────────────────────────
+
+
+def test_pick_field_returns_entry_in_preferred_script():
+    entries = [
+        {"title": "祖堅正慶"},
+        {"title": "Masayoshi Soken"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "Masayoshi Soken"
+
+
+def test_pick_field_falls_back_to_first_when_no_match():
+    entries = [
+        {"title": "祖堅正慶"},
+        {"title": "最終幻想"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "祖堅正慶"
+
+
+def test_pick_field_returns_first_when_it_already_matches():
+    entries = [
+        {"title": "Masayoshi Soken"},
+        {"title": "祖堅正慶"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "Masayoshi Soken"

--- a/app/tests/test_fingerprint.py
+++ b/app/tests/test_fingerprint.py
@@ -7,7 +7,7 @@ import hmac
 import pytest
 
 import fingerprint
-from fingerprint import _build_signature
+from fingerprint import _build_signature, _dominant_script
 
 # ── Signature generation ──────────────────────────────────────────────────────
 
@@ -197,3 +197,34 @@ def test_identify_audio_posts_to_correct_url(monkeypatch, configured_credentials
     fingerprint.identify_audio(b"audio")
 
     assert posted_urls == ["https://identify.acrcloud.com/v1/identify"]
+
+
+# ── _dominant_script ──────────────────────────────────────────────────────────
+
+
+def test_dominant_script_latin():
+    assert _dominant_script("Masayoshi Soken") == "latin"
+
+
+def test_dominant_script_cjk_kanji():
+    assert _dominant_script("祖堅正慶") == "cjk"
+
+
+def test_dominant_script_cjk_hiragana():
+    assert _dominant_script("あいうえお") == "cjk"
+
+
+def test_dominant_script_hangul():
+    assert _dominant_script("마마무") == "hangul"
+
+
+def test_dominant_script_cyrillic():
+    assert _dominant_script("Земфира") == "cyrillic"
+
+
+def test_dominant_script_unknown_for_punctuation():
+    assert _dominant_script("!!!") == "unknown"
+
+
+def test_dominant_script_empty_string():
+    assert _dominant_script("") == "unknown"

--- a/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
+++ b/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
@@ -1,0 +1,808 @@
+# ACRCloud Language Preference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Return track title, artist, and album names from ACRCloud in the user's preferred language, auto-detected from the Windows locale with an INI override.
+
+**Architecture:** Two selection mechanisms are layered: (1) `_pick_lang` checks a field's `langs` array for a BCP-47 match; (2) if the result is still in the wrong script, `_pick_field` scans all `music[]` entries for one whose primary field is in the preferred script. Language preference is read from config (INI → Windows registry → `"en"`).
+
+**Tech Stack:** Python, `winreg` (lazy import, Windows-only), `configparser`, `pytest`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `app/config.py` | Add `get_acrcloud_language()` after `get_acrcloud_access_secret()` |
+| `app/fingerprint.py` | Add `_SCRIPT_PREFIXES`, `_dominant_script()`, `_preferred_script()`, `_pick_lang()`, `_pick_field()` between `_build_signature` and `identify_audio`; replace `identify_audio()` body |
+| `app/euterpium.ini` | Add commented `language` key to `[acrcloud]` section |
+| `app/tests/test_config.py` | Add tests for `get_acrcloud_language()` |
+| `app/tests/test_fingerprint.py` | Add tests for all new helpers + 4 integration tests |
+
+---
+
+### Task 1: `config.get_acrcloud_language()`
+
+**Files:**
+- Modify: `app/config.py` (after `get_acrcloud_access_secret()`)
+- Modify: `app/tests/test_config.py` (append new tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the top of `app/tests/test_config.py` (after existing imports):
+
+```python
+import sys
+import types
+```
+
+Append to `app/tests/test_config.py`:
+
+```python
+# ── ACRCloud language ──────────────────────────────────────────────────────────
+
+
+def test_get_acrcloud_language_explicit_ini(tmp_config):
+    config.save({"acrcloud": {"language": "ja"}})
+    assert config.get_acrcloud_language() == "ja"
+
+
+def test_get_acrcloud_language_from_registry(tmp_config, monkeypatch):
+    fake_winreg = types.ModuleType("winreg")
+    fake_winreg.HKEY_CURRENT_USER = 0
+
+    class _FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    fake_winreg.OpenKey = lambda *a: _FakeKey()
+    fake_winreg.QueryValueEx = lambda key, name: ("en-GB", 1)
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    assert config.get_acrcloud_language() == "en-GB"
+
+
+def test_get_acrcloud_language_registry_error_returns_en(tmp_config, monkeypatch):
+    fake_winreg = types.ModuleType("winreg")
+    fake_winreg.HKEY_CURRENT_USER = 0
+
+    def _raise(*a):
+        raise OSError("no registry")
+
+    fake_winreg.OpenKey = _raise
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    assert config.get_acrcloud_language() == "en"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_config.py -k "acrcloud_language" -v
+```
+
+Expected: 3 FAILs with `AttributeError: module 'config' has no attribute 'get_acrcloud_language'`
+
+- [ ] **Step 3: Implement `get_acrcloud_language()`**
+
+Add to `app/config.py` after `get_acrcloud_access_secret()`:
+
+```python
+def get_acrcloud_language() -> str:
+    """Returns the preferred language code for ACRCloud results.
+
+    Priority: [acrcloud] language in INI → Windows locale → 'en'.
+    """
+    explicit = _cfg().get("acrcloud", "language", fallback="").strip()
+    if explicit:
+        return explicit
+    try:
+        import winreg
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as key:
+            value, _ = winreg.QueryValueEx(key, "LocaleName")
+            return value.strip() if value.strip() else "en"
+    except Exception:
+        return "en"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd app && poetry run pytest tests/test_config.py -k "acrcloud_language" -v
+```
+
+Expected: 3 PASSes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config.py app/tests/test_config.py
+git commit -m "feat: add config.get_acrcloud_language() with Windows locale detection"
+```
+
+---
+
+### Task 2: `fingerprint._dominant_script()`
+
+**Files:**
+- Modify: `app/fingerprint.py` (add before `identify_audio`)
+- Modify: `app/tests/test_fingerprint.py` (append new tests + update import)
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the import line at the top of `app/tests/test_fingerprint.py` from:
+
+```python
+from fingerprint import _build_signature
+```
+
+to:
+
+```python
+from fingerprint import _build_signature, _dominant_script
+```
+
+Append to `app/tests/test_fingerprint.py`:
+
+```python
+# ── _dominant_script ──────────────────────────────────────────────────────────
+
+
+def test_dominant_script_latin():
+    assert _dominant_script("Masayoshi Soken") == "latin"
+
+
+def test_dominant_script_cjk_kanji():
+    assert _dominant_script("祖堅正慶") == "cjk"
+
+
+def test_dominant_script_cjk_hiragana():
+    assert _dominant_script("あいうえお") == "cjk"
+
+
+def test_dominant_script_hangul():
+    assert _dominant_script("마마무") == "hangul"
+
+
+def test_dominant_script_cyrillic():
+    assert _dominant_script("Земфира") == "cyrillic"
+
+
+def test_dominant_script_unknown_for_punctuation():
+    assert _dominant_script("!!!") == "unknown"
+
+
+def test_dominant_script_empty_string():
+    assert _dominant_script("") == "unknown"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "dominant_script" -v
+```
+
+Expected: 7 FAILs with `ImportError: cannot import name '_dominant_script'`
+
+- [ ] **Step 3: Add `_dominant_script()` to `fingerprint.py`**
+
+Insert after the `_build_signature` function (before `identify_audio`) in `app/fingerprint.py`:
+
+```python
+def _dominant_script(text: str) -> str:
+    counts: dict[str, int] = {"latin": 0, "cjk": 0, "hangul": 0, "cyrillic": 0}
+    for ch in text:
+        cp = ord(ch)
+        if 0x0041 <= cp <= 0x024F:
+            counts["latin"] += 1
+        elif 0x3040 <= cp <= 0x30FF or 0x3400 <= cp <= 0x4DBF or 0x4E00 <= cp <= 0x9FFF:
+            counts["cjk"] += 1
+        elif 0x1100 <= cp <= 0x11FF or 0xAC00 <= cp <= 0xD7AF:
+            counts["hangul"] += 1
+        elif 0x0400 <= cp <= 0x04FF:
+            counts["cyrillic"] += 1
+    if not any(counts.values()):
+        return "unknown"
+    return max(counts, key=counts.get)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "dominant_script" -v
+```
+
+Expected: 7 PASSes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/fingerprint.py app/tests/test_fingerprint.py
+git commit -m "feat: add fingerprint._dominant_script() for Unicode script detection"
+```
+
+---
+
+### Task 3: `fingerprint._preferred_script()`
+
+**Files:**
+- Modify: `app/fingerprint.py` (add after `_dominant_script`)
+- Modify: `app/tests/test_fingerprint.py` (append tests + update import)
+
+- [ ] **Step 1: Write the failing tests**
+
+Update import in `app/tests/test_fingerprint.py`:
+
+```python
+from fingerprint import _build_signature, _dominant_script, _preferred_script
+```
+
+Append to `app/tests/test_fingerprint.py`:
+
+```python
+# ── _preferred_script ─────────────────────────────────────────────────────────
+
+
+def test_preferred_script_en_is_latin():
+    assert _preferred_script("en") == "latin"
+
+
+def test_preferred_script_en_gb_is_latin():
+    assert _preferred_script("en-GB") == "latin"
+
+
+def test_preferred_script_ja_is_cjk():
+    assert _preferred_script("ja") == "cjk"
+
+
+def test_preferred_script_zh_hans_is_cjk():
+    assert _preferred_script("zh-Hans") == "cjk"
+
+
+def test_preferred_script_zh_hans_cn_is_cjk():
+    assert _preferred_script("zh-Hans-CN") == "cjk"
+
+
+def test_preferred_script_ko_is_hangul():
+    assert _preferred_script("ko") == "hangul"
+
+
+def test_preferred_script_ru_is_cyrillic():
+    assert _preferred_script("ru") == "cyrillic"
+
+
+def test_preferred_script_unknown_code_defaults_to_latin():
+    assert _preferred_script("xx-Unknown") == "latin"
+
+
+def test_preferred_script_empty_string_defaults_to_latin():
+    assert _preferred_script("") == "latin"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "preferred_script" -v
+```
+
+Expected: 9 FAILs with `ImportError: cannot import name '_preferred_script'`
+
+- [ ] **Step 3: Add `_SCRIPT_PREFIXES` and `_preferred_script()` to `fingerprint.py`**
+
+Insert after `_dominant_script()` in `app/fingerprint.py`:
+
+```python
+_SCRIPT_PREFIXES: dict[str, tuple[str, ...]] = {
+    "cjk": ("ja", "zh"),
+    "hangul": ("ko",),
+    "cyrillic": ("ru", "uk", "bg", "sr", "be"),
+}
+
+
+def _preferred_script(lang_code: str) -> str:
+    lower = lang_code.lower()
+    for script, prefixes in _SCRIPT_PREFIXES.items():
+        if any(lower == p or lower.startswith(p + "-") for p in prefixes):
+            return script
+    return "latin"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "preferred_script" -v
+```
+
+Expected: 9 PASSes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/fingerprint.py app/tests/test_fingerprint.py
+git commit -m "feat: add fingerprint._preferred_script() mapping BCP-47 codes to scripts"
+```
+
+---
+
+### Task 4: `fingerprint._pick_lang()`
+
+**Files:**
+- Modify: `app/fingerprint.py` (add after `_preferred_script`)
+- Modify: `app/tests/test_fingerprint.py` (append tests + update import)
+
+- [ ] **Step 1: Write the failing tests**
+
+Update import in `app/tests/test_fingerprint.py`:
+
+```python
+from fingerprint import _build_signature, _dominant_script, _preferred_script, _pick_lang
+```
+
+Append to `app/tests/test_fingerprint.py`:
+
+```python
+# ── _pick_lang ────────────────────────────────────────────────────────────────
+
+
+def test_pick_lang_exact_match():
+    langs = [{"code": "zh-Hans", "name": "你好"}]
+    assert _pick_lang("Hello", langs, "zh-Hans") == "你好"
+
+
+def test_pick_lang_prefix_match_strips_region():
+    langs = [{"code": "en", "name": "Hello"}]
+    assert _pick_lang("Hola", langs, "en-GB") == "Hello"
+
+
+def test_pick_lang_multi_level_strip():
+    langs = [{"code": "zh-Hans", "name": "你好"}]
+    assert _pick_lang("Hello", langs, "zh-Hans-CN") == "你好"
+
+
+def test_pick_lang_no_match_returns_primary():
+    langs = [{"code": "ja", "name": "こんにちは"}]
+    assert _pick_lang("Hello", langs, "en") == "Hello"
+
+
+def test_pick_lang_empty_langs_returns_primary():
+    assert _pick_lang("Hello", [], "en") == "Hello"
+
+
+def test_pick_lang_empty_preferred_returns_primary():
+    langs = [{"code": "en", "name": "Hello"}]
+    assert _pick_lang("Hola", langs, "") == "Hola"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "pick_lang" -v
+```
+
+Expected: 6 FAILs with `ImportError: cannot import name '_pick_lang'`
+
+- [ ] **Step 3: Add `_pick_lang()` to `fingerprint.py`**
+
+Insert after `_preferred_script()` in `app/fingerprint.py`:
+
+```python
+def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
+    if not langs or not preferred:
+        return primary
+    candidate = preferred
+    while candidate:
+        for entry in langs:
+            if entry.get("code", "").lower() == candidate.lower():
+                return entry["name"]
+        if "-" not in candidate:
+            break
+        candidate = candidate.rsplit("-", 1)[0]
+    return primary
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "pick_lang" -v
+```
+
+Expected: 6 PASSes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/fingerprint.py app/tests/test_fingerprint.py
+git commit -m "feat: add fingerprint._pick_lang() for langs-array language selection"
+```
+
+---
+
+### Task 5: `fingerprint._pick_field()`
+
+**Files:**
+- Modify: `app/fingerprint.py` (add after `_pick_lang`)
+- Modify: `app/tests/test_fingerprint.py` (append tests + update import)
+
+- [ ] **Step 1: Write the failing tests**
+
+Update import in `app/tests/test_fingerprint.py`:
+
+```python
+from fingerprint import _build_signature, _dominant_script, _preferred_script, _pick_lang, _pick_field
+```
+
+Append to `app/tests/test_fingerprint.py`:
+
+```python
+# ── _pick_field ───────────────────────────────────────────────────────────────
+
+
+def test_pick_field_returns_entry_in_preferred_script():
+    entries = [
+        {"title": "祖堅正慶"},
+        {"title": "Masayoshi Soken"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "Masayoshi Soken"
+
+
+def test_pick_field_falls_back_to_first_when_no_match():
+    entries = [
+        {"title": "祖堅正慶"},
+        {"title": "最終幻想"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "祖堅正慶"
+
+
+def test_pick_field_returns_first_when_it_already_matches():
+    entries = [
+        {"title": "Masayoshi Soken"},
+        {"title": "祖堅正慶"},
+    ]
+    assert _pick_field(entries, lambda e: e["title"], "latin") == "Masayoshi Soken"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "pick_field" -v
+```
+
+Expected: 3 FAILs with `ImportError: cannot import name '_pick_field'`
+
+- [ ] **Step 3: Add `_pick_field()` to `fingerprint.py`**
+
+Insert after `_pick_lang()` in `app/fingerprint.py`:
+
+```python
+def _pick_field(entries: list[dict], field_fn, preferred_script: str) -> str:
+    for entry in entries:
+        value = field_fn(entry)
+        if value and _dominant_script(value) == preferred_script:
+            return value
+    return field_fn(entries[0])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "pick_field" -v
+```
+
+Expected: 3 PASSes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/fingerprint.py app/tests/test_fingerprint.py
+git commit -m "feat: add fingerprint._pick_field() for script-based music[] entry scanning"
+```
+
+---
+
+### Task 6: Update `identify_audio()`
+
+**Files:**
+- Modify: `app/fingerprint.py` (replace `identify_audio` body)
+- Modify: `app/tests/test_fingerprint.py` (append integration tests)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `app/tests/test_fingerprint.py`:
+
+```python
+# ── identify_audio — language selection ──────────────────────────────────────
+
+
+def test_identify_audio_picks_title_from_langs(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "你好",
+                        "langs": [{"code": "en", "name": "Hello"}],
+                        "artists": [{"name": "Artist"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["title"] == "Hello"
+
+
+def test_identify_audio_picks_artist_by_script_scan(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "The Aetherial Sea",
+                        "artists": [{"name": "祖堅正慶"}],
+                        "album": {"name": "ENDWALKER: FINAL FANTASY XIV Original Soundtrack"},
+                        "release_date": "2022-02-23",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "The Aetherial Sea",
+                        "artists": [{"name": "Masayoshi Soken"}],
+                        "album": {"name": "ENDWALKER: FINAL FANTASY XIV Original Soundtrack"},
+                        "release_date": "2022-02-23",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["artist"] == "Masayoshi Soken"
+
+
+def test_identify_audio_script_scan_falls_back_to_first_entry(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "曲名",
+                        "artists": [{"name": "アーティスト"}],
+                        "album": {"name": "アルバム"},
+                        "release_date": "",
+                        "acrid": "abc",
+                        "external_metadata": {},
+                    }
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["artist"] == "アーティスト"
+
+
+def test_identify_audio_langs_title_and_script_scan_artist(monkeypatch, configured_credentials):
+    response = _make_response(
+        {
+            "status": {"code": 0, "msg": "Success"},
+            "metadata": {
+                "music": [
+                    {
+                        "title": "你好",
+                        "langs": [{"code": "en", "name": "Hello"}],
+                        "artists": [{"name": "祖堅正慶"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc1",
+                        "external_metadata": {},
+                    },
+                    {
+                        "title": "你好",
+                        "artists": [{"name": "Masayoshi Soken"}],
+                        "album": {"name": "Album"},
+                        "release_date": "",
+                        "acrid": "abc2",
+                        "external_metadata": {},
+                    },
+                ]
+            },
+        }
+    )
+    monkeypatch.setattr(fingerprint.requests, "post", lambda *a, **kw: response)
+    monkeypatch.setattr(fingerprint.config, "get_acrcloud_language", lambda: "en")
+
+    result = fingerprint.identify_audio(b"audio")
+    assert result["title"] == "Hello"
+    assert result["artist"] == "Masayoshi Soken"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -k "identify_audio and (langs or script_scan)" -v
+```
+
+Expected: 4 FAILs — `identify_audio` still returns `music[0]` primary values without language selection
+
+- [ ] **Step 3: Replace `identify_audio()` body in `fingerprint.py`**
+
+Replace the entire `identify_audio` function with:
+
+```python
+def identify_audio(wav_bytes: bytes) -> dict | None:
+    """
+    Sends WAV audio bytes to ACRCloud for identification.
+    Returns a normalised result dict on success, or None if unrecognised / error.
+
+    Result dict keys:
+        title, artist, album, release_date, acrid, streaming_links
+
+    ``streaming_links`` contains the raw ACRCloud ``external_metadata`` object
+    verbatim — a dict keyed by platform (e.g. ``spotify``, ``deezer``,
+    ``youtube``, ``musicbrainz``) whose values are platform-specific nested
+    dicts/lists.  The exact shape depends on what ACRCloud returns for the
+    matched track.
+    """
+    # Read credentials fresh each call so settings changes take effect immediately
+    access_key = config.get_acrcloud_access_key()
+    access_secret = config.get_acrcloud_access_secret()
+    host = config.get_acrcloud_host()
+
+    if not access_key or not access_secret:
+        logger.warning("ACRCloud credentials not configured — skipping fingerprint")
+        return None
+
+    acrcloud_url = f"https://{host}/v1/identify"
+    timestamp = str(int(time.time()))
+    signature = _build_signature(timestamp, access_key, access_secret)
+
+    files = {
+        "sample": ("sample.wav", wav_bytes, "audio/wav"),
+    }
+    data = {
+        "access_key": access_key,
+        "sample_bytes": str(len(wav_bytes)),
+        "timestamp": timestamp,
+        "signature": signature,
+        "data_type": "audio",
+        "signature_version": "1",
+    }
+
+    try:
+        response = requests.post(acrcloud_url, files=files, data=data, timeout=15)
+        response.raise_for_status()
+        result = response.json()
+    except requests.RequestException as e:
+        logger.error(f"ACRCloud request failed: {e}")
+        return None
+
+    status = result.get("status", {})
+    if status.get("code") != 0:
+        msg = status.get("msg", "Unknown")
+        if status.get("code") == 1001:
+            logger.debug("ACRCloud: no result found")
+        else:
+            logger.warning(f"ACRCloud error {status.get('code')}: {msg}")
+        return None
+
+    try:
+        music_list = result["metadata"]["music"]
+        music = music_list[0]
+
+        preferred_lang = config.get_acrcloud_language()
+        preferred_script = _preferred_script(preferred_lang)
+
+        def _artist_str(entry: dict) -> str:
+            return ", ".join(a["name"] for a in entry.get("artists", []))
+
+        title = _pick_lang(music.get("title", ""), music.get("langs", []), preferred_lang)
+        if _dominant_script(title) != preferred_script:
+            title = _pick_field(music_list, lambda e: e.get("title", ""), preferred_script)
+
+        artist = ", ".join(
+            _pick_lang(a["name"], a.get("langs", []), preferred_lang)
+            for a in music.get("artists", [])
+        )
+        if _dominant_script(artist) != preferred_script:
+            artist = _pick_field(music_list, _artist_str, preferred_script)
+
+        album_info = music.get("album", {})
+        album = _pick_lang(album_info.get("name", ""), album_info.get("langs", []), preferred_lang)
+        if _dominant_script(album) != preferred_script:
+            album = _pick_field(
+                music_list, lambda e: e.get("album", {}).get("name", ""), preferred_script
+            )
+
+        return {
+            "source": "acrcloud",
+            "title": title,
+            "artist": artist,
+            "album": album,
+            "release_date": music.get("release_date", ""),
+            "acrid": music.get("acrid", ""),
+            "streaming_links": music.get("external_metadata", {}),
+        }
+
+    except (KeyError, IndexError) as e:
+        logger.error(f"ACRCloud response parse error: {e}")
+        return None
+```
+
+- [ ] **Step 4: Run the full fingerprint test suite**
+
+```
+cd app && poetry run pytest tests/test_fingerprint.py -v
+```
+
+Expected: all tests pass, including the 4 existing `identify_audio` tests and 4 new integration tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/fingerprint.py app/tests/test_fingerprint.py
+git commit -m "feat: apply language preference in identify_audio via langs + script scanning"
+```
+
+---
+
+### Task 7: Update `euterpium.ini` and final check
+
+**Files:**
+- Modify: `app/euterpium.ini`
+
+- [ ] **Step 1: Add the commented language key to `[acrcloud]`**
+
+In `app/euterpium.ini`, update the `[acrcloud]` section from:
+
+```ini
+[acrcloud]
+host        = identify-eu-west-1.acrcloud.com
+access_key  =
+access_secret =
+```
+
+to:
+
+```ini
+[acrcloud]
+host          = identify-eu-west-1.acrcloud.com
+access_key    =
+access_secret =
+; Preferred language for track/artist/album names returned by ACRCloud.
+; Leave blank to auto-detect from Windows locale. Examples: en, ja, zh-Hans
+; language =
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```
+cd app && poetry run pytest tests/ -q
+```
+
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/euterpium.ini
+git commit -m "docs: document acrcloud language preference key in bundled euterpium.ini"
+```

--- a/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
+++ b/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
@@ -103,10 +103,15 @@ def get_acrcloud_language() -> str:
 
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\International") as key:
             value, _ = winreg.QueryValueEx(key, "LocaleName")
-            return value.strip() if value.strip() else "en"
-    except Exception:
+            if not isinstance(value, str):
+                return "en"
+            stripped = value.strip()
+            return stripped if stripped else "en"
+    except (ImportError, OSError):
         return "en"
 ```
+
+The narrow `(ImportError, OSError)` catch is consistent with the rest of `config.py` (specific exceptions, not bare `except Exception`). The `isinstance(value, str)` guard handles the realistic non-string failure mode (e.g. registry returns `None`) without re-broadening the catch.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -731,8 +736,8 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
             for a in music.get("artists", [])
         ]
         artist = ", ".join(value for value, _ in artist_results if value)
-        all_artists_matched = bool(artist_results) and all(matched for _, matched in artist_results)
-        if not all_artists_matched and _dominant_script(artist) != preferred_script:
+        any_artist_matched = any(matched for _, matched in artist_results)
+        if not any_artist_matched and _dominant_script(artist) != preferred_script:
             artist = _pick_field(music_list, _artist_str, preferred_script)
 
         album_info = music.get("album", {})

--- a/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
+++ b/docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md
@@ -349,31 +349,31 @@ Append to `app/tests/test_fingerprint.py`:
 
 def test_pick_lang_exact_match():
     langs = [{"code": "zh-Hans", "name": "你好"}]
-    assert _pick_lang("Hello", langs, "zh-Hans") == "你好"
+    assert _pick_lang("Hello", langs, "zh-Hans") == ("你好", True)
 
 
 def test_pick_lang_prefix_match_strips_region():
     langs = [{"code": "en", "name": "Hello"}]
-    assert _pick_lang("Hola", langs, "en-GB") == "Hello"
+    assert _pick_lang("Hola", langs, "en-GB") == ("Hello", True)
 
 
 def test_pick_lang_multi_level_strip():
     langs = [{"code": "zh-Hans", "name": "你好"}]
-    assert _pick_lang("Hello", langs, "zh-Hans-CN") == "你好"
+    assert _pick_lang("Hello", langs, "zh-Hans-CN") == ("你好", True)
 
 
 def test_pick_lang_no_match_returns_primary():
     langs = [{"code": "ja", "name": "こんにちは"}]
-    assert _pick_lang("Hello", langs, "en") == "Hello"
+    assert _pick_lang("Hello", langs, "en") == ("Hello", False)
 
 
 def test_pick_lang_empty_langs_returns_primary():
-    assert _pick_lang("Hello", [], "en") == "Hello"
+    assert _pick_lang("Hello", [], "en") == ("Hello", False)
 
 
 def test_pick_lang_empty_preferred_returns_primary():
     langs = [{"code": "en", "name": "Hello"}]
-    assert _pick_lang("Hola", langs, "") == "Hola"
+    assert _pick_lang("Hola", langs, "") == ("Hola", False)
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -389,19 +389,23 @@ Expected: 6 FAILs with `ImportError: cannot import name '_pick_lang'`
 Insert after `_preferred_script()` in `app/fingerprint.py`:
 
 ```python
-def _pick_lang(primary: str, langs: list[dict], preferred: str) -> str:
+def _pick_lang(primary: str, langs: list[dict], preferred: str) -> tuple[str, bool]:
     if not langs or not preferred:
-        return primary
+        return primary, False
     candidate = preferred
     while candidate:
         for entry in langs:
             if entry.get("code", "").lower() == candidate.lower():
-                return entry["name"]
+                name = entry.get("name")
+                if name:
+                    return name, True
         if "-" not in candidate:
             break
         candidate = candidate.rsplit("-", 1)[0]
-    return primary
+    return primary, False
 ```
+
+The `(value, matched)` tuple lets callers preserve langs-pass priority: when `matched` is True they should skip the script-scan fallback regardless of what script the localized name happens to be in.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -712,22 +716,30 @@ def identify_audio(wav_bytes: bytes) -> dict | None:
         preferred_script = _preferred_script(preferred_lang)
 
         def _artist_str(entry: dict) -> str:
-            return ", ".join(a["name"] for a in entry.get("artists", []))
+            return ", ".join(
+                name for a in entry.get("artists", []) if (name := a.get("name", ""))
+            )
 
-        title = _pick_lang(music.get("title", ""), music.get("langs", []), preferred_lang)
-        if _dominant_script(title) != preferred_script:
+        title, title_matched = _pick_lang(
+            music.get("title", ""), music.get("langs", []), preferred_lang
+        )
+        if not title_matched and _dominant_script(title) != preferred_script:
             title = _pick_field(music_list, lambda e: e.get("title", ""), preferred_script)
 
-        artist = ", ".join(
-            _pick_lang(a["name"], a.get("langs", []), preferred_lang)
+        artist_results = [
+            _pick_lang(a.get("name", ""), a.get("langs", []), preferred_lang)
             for a in music.get("artists", [])
-        )
-        if _dominant_script(artist) != preferred_script:
+        ]
+        artist = ", ".join(value for value, _ in artist_results if value)
+        all_artists_matched = bool(artist_results) and all(matched for _, matched in artist_results)
+        if not all_artists_matched and _dominant_script(artist) != preferred_script:
             artist = _pick_field(music_list, _artist_str, preferred_script)
 
         album_info = music.get("album", {})
-        album = _pick_lang(album_info.get("name", ""), album_info.get("langs", []), preferred_lang)
-        if _dominant_script(album) != preferred_script:
+        album, album_matched = _pick_lang(
+            album_info.get("name", ""), album_info.get("langs", []), preferred_lang
+        )
+        if not album_matched and _dominant_script(album) != preferred_script:
             album = _pick_field(
                 music_list, lambda e: e.get("album", {}).get("name", ""), preferred_script
             )

--- a/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
+++ b/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
@@ -1,0 +1,106 @@
+# ACRCloud Language Preference
+
+**Date:** 2026-04-26
+**Status:** Approved
+
+## Problem
+
+ACRCloud can return track title, artist name, and album name in multiple languages via a `langs` array on each field. The current code always uses the primary (top-level) value. Users whose Windows locale differs from the primary language get whichever language ACRCloud happens to return first.
+
+## Goal
+
+Pick the user's preferred language from the `langs` array when available, falling back to the primary value if no match is found. Default to auto-detecting the preferred language from Windows, with an INI override for power users.
+
+## Approach — Auto-detect with INI override
+
+- Default: read the preferred language from `HKCU\Control Panel\International\LocaleName` (returns BCP-47, e.g. `en-GB`, `zh-Hans-CN`, `ja-JP`).
+- Override: if `[acrcloud] language` is set in `euterpium.ini`, use that value instead.
+- Final fallback: `en` if the registry read fails or returns empty.
+
+No settings UI change required.
+
+## ACRCloud Response Shape
+
+The `langs` field may appear on `music[].title` (as a top-level key alongside `title`), `music[].artists[].name`, and `music[].album.name`. Each entry is `{"code": "<BCP-47>", "name": "<localized string>"}`. Example:
+
+```json
+{
+  "title": "Hello",
+  "langs": [{"code": "zh-Hans", "name": "你好"}],
+  "artists": [{"name": "Artist", "langs": [{"code": "zh-Hans", "name": "艺术家"}]}],
+  "album": {"name": "Album", "langs": [{"code": "zh-Hans", "name": "专辑"}]}
+}
+```
+
+## Components
+
+### `config.get_acrcloud_language() -> str`
+
+1. Read `[acrcloud] language` from INI. If non-empty, return it.
+2. Lazy-import `winreg` (startup.py pattern — Windows-only module).
+3. Read `HKCU\Control Panel\International\LocaleName`.
+4. Return the registry value, or `"en"` on any failure.
+
+### `fingerprint._pick_lang(primary: str, langs: list[dict], preferred: str) -> str`
+
+Selects the best available name for a single field:
+
+1. Return `primary` immediately if `langs` is empty or `preferred` is empty.
+2. Try exact match: find entry where `code == preferred`.
+3. Progressively strip the trailing subtag and retry: `en-GB` → `en`, `zh-Hans-CN` → `zh-Hans` → `zh`.
+4. Return the matched `name`, or `primary` if nothing matched.
+
+### `fingerprint.identify_audio` — updated
+
+Call `config.get_acrcloud_language()` once per invocation, then apply `_pick_lang` to:
+
+- `music["title"]` + `music.get("langs", [])`
+- Each `artist["name"]` + `artist.get("langs", [])`
+- `album["name"]` + `album.get("langs", [])`
+
+### `euterpium.ini` — bundled default
+
+Add a commented-out key to the `[acrcloud]` section:
+
+```ini
+; Preferred language for track/artist/album names returned by ACRCloud.
+; Leave blank to auto-detect from Windows. Examples: en, ja, zh-Hans
+; language =
+```
+
+## Error Handling
+
+- Registry unavailable (non-Windows, permission error): silently fall back to `"en"`.
+- `langs` field absent on a music entry: `_pick_lang` receives an empty list and returns `primary` — no change from current behaviour.
+- Unrecognised language code in INI: treated as a literal and matched against `langs` entries; if no match, falls back to primary. No validation or warning.
+
+## Testing
+
+### `test_fingerprint.py` — `_pick_lang`
+
+| Scenario | Expected |
+|---|---|
+| Exact match (`zh-Hans`) | Returns localized name |
+| Prefix match (`en-GB` → finds `en`) | Returns localized name |
+| Multi-level strip (`zh-Hans-CN` → finds `zh-Hans`) | Returns localized name |
+| No match in `langs` | Returns `primary` |
+| `langs` is empty list | Returns `primary` |
+| `preferred` is empty string | Returns `primary` |
+
+### `test_fingerprint.py` — `identify_audio`
+
+Extend the existing success fixture to include `langs` on title, artist, and album. Assert the preferred language name is returned for each field.
+
+### `test_config.py` — `get_acrcloud_language`
+
+| Scenario | Expected |
+|---|---|
+| INI has explicit value | Returns INI value (no registry read) |
+| INI empty, registry returns `en-GB` | Returns `en-GB` |
+| INI empty, registry raises `OSError` | Returns `"en"` |
+
+## Out of Scope
+
+- Settings UI control for language preference.
+- Language preference for the `streaming_links` / `external_metadata` payload (passed through verbatim).
+- Validation or enumeration of supported ACRCloud language codes.

--- a/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
+++ b/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
@@ -5,11 +5,14 @@
 
 ## Problem
 
-ACRCloud can return track title, artist name, and album name in multiple languages via a `langs` array on each field. The current code always uses the primary (top-level) value. Users whose Windows locale differs from the primary language get whichever language ACRCloud happens to return first.
+ACRCloud responses contain two distinct language-selection challenges:
+
+1. **`langs` field** — some fields carry a `langs` array of localized alternatives (e.g. a Chinese song whose primary `title` is English with a `zh-Hans` translation in `langs`). The current code always uses the primary value.
+2. **`music[]` entry language** — ACRCloud returns multiple database entries for the same track. Different entries may have the same audio fingerprint but different primary languages for artist names (e.g. `"祖堅正慶"` vs `"Masayoshi Soken"`). The current code always picks `[0]`, which may be in the wrong script for the user.
 
 ## Goal
 
-Pick the user's preferred language from the `langs` array when available, falling back to the primary value if no match is found. Default to auto-detecting the preferred language from Windows, with an INI override for power users.
+Return track title, artist, and album names in the user's preferred language. Default to auto-detecting from Windows locale, with an INI override for power users.
 
 ## Approach — Auto-detect with INI override
 
@@ -32,6 +35,8 @@ The `langs` field may appear on `music[].title` (as a top-level key alongside `t
 }
 ```
 
+In practice, `langs` on artist/album is less common; the more frequent case is multiple `music[]` entries with different primary-language artist names.
+
 ## Components
 
 ### `config.get_acrcloud_language() -> str`
@@ -43,20 +48,58 @@ The `langs` field may appear on `music[].title` (as a top-level key alongside `t
 
 ### `fingerprint._pick_lang(primary: str, langs: list[dict], preferred: str) -> str`
 
-Selects the best available name for a single field:
+Selects the best available name using the `langs` array:
 
 1. Return `primary` immediately if `langs` is empty or `preferred` is empty.
 2. Try exact match: find entry where `code == preferred`.
 3. Progressively strip the trailing subtag and retry: `en-GB` → `en`, `zh-Hans-CN` → `zh-Hans` → `zh`.
 4. Return the matched `name`, or `primary` if nothing matched.
 
+### `fingerprint._dominant_script(text: str) -> str`
+
+Detects the dominant Unicode script of a string using character range counting. Returns one of `"latin"`, `"cjk"`, `"hangul"`, `"cyrillic"`, or `"unknown"`.
+
+Unicode ranges checked:
+- **Latin**: U+0041–U+024F (Basic Latin + Latin Extended A/B)
+- **CJK**: U+3040–U+30FF (Hiragana/Katakana) + U+3400–U+4DBF (CJK Ext A) + U+4E00–U+9FFF (CJK Unified)
+- **Hangul**: U+1100–U+11FF + U+AC00–U+D7AF
+- **Cyrillic**: U+0400–U+04FF
+
+Returns the script with the highest character count. Returns `"unknown"` if no script characters are found (e.g. punctuation-only strings).
+
+### `fingerprint._preferred_script(lang_code: str) -> str`
+
+Maps a BCP-47 language code to the expected script:
+
+| Script | Language codes (prefix-matched) |
+|---|---|
+| `"cjk"` | `ja`, `zh` |
+| `"hangul"` | `ko` |
+| `"cyrillic"` | `ru`, `uk`, `bg`, `sr`, `be` |
+| `"latin"` | everything else (default) |
+
+Prefix matching: `zh-Hans`, `zh-Hant`, `zh-Hans-CN` all map to `"cjk"` via the `zh` prefix.
+
+### `fingerprint._pick_field(entries: list[dict], field_fn, preferred_script: str) -> str`
+
+Scans a list of `music[]` entries for a field value in the preferred script:
+
+1. For each entry in order, extract the candidate value via `field_fn(entry)`.
+2. If `_dominant_script(candidate) == preferred_script`, return it.
+3. If no entry matches, return `field_fn(entries[0])` as fallback.
+
+`field_fn` is a callable that extracts a string from a music entry (e.g. `lambda e: e.get("title", "")`).
+
 ### `fingerprint.identify_audio` — updated
 
-Call `config.get_acrcloud_language()` once per invocation, then apply `_pick_lang` to:
+Call `config.get_acrcloud_language()` and `_preferred_script()` once per invocation.
 
-- `music["title"]` + `music.get("langs", [])`
-- Each `artist["name"]` + `artist.get("langs", [])`
-- `album["name"]` + `album.get("langs", [])`
+For each of title, artist names, and album name — two-pass selection:
+
+1. **`langs` pass**: apply `_pick_lang` to the `music[0]` field + its `langs` array.
+2. **Script pass**: if the result's dominant script does not match the preferred script, use `_pick_field` to scan all `music[]` entries for one in the preferred script.
+
+The `langs` pass takes priority — if it finds a match, the script scan is skipped for that field.
 
 ### `euterpium.ini` — bundled default
 
@@ -72,7 +115,9 @@ Add a commented-out key to the `[acrcloud]` section:
 
 - Registry unavailable (non-Windows, permission error): silently fall back to `"en"`.
 - `langs` field absent on a music entry: `_pick_lang` receives an empty list and returns `primary` — no change from current behaviour.
-- Unrecognised language code in INI: treated as a literal and matched against `langs` entries; if no match, falls back to primary. No validation or warning.
+- `music[]` has only one entry: `_pick_field` returns that entry's value directly.
+- Unrecognised language code in INI: treated as a literal; `_pick_lang` falls back to primary, `_preferred_script` falls back to `"latin"`. No validation or warning.
+- Punctuation-only or very short strings where `_dominant_script` returns `"unknown"`: treated as not matching any preferred script, so the scan continues to the next entry; falls back to `music[0]` value.
 
 ## Testing
 
@@ -87,9 +132,33 @@ Add a commented-out key to the `[acrcloud]` section:
 | `langs` is empty list | Returns `primary` |
 | `preferred` is empty string | Returns `primary` |
 
-### `test_fingerprint.py` — `identify_audio`
+### `test_fingerprint.py` — `_dominant_script`
 
-Extend the existing success fixture to include `langs` on title, artist, and album. Assert the preferred language name is returned for each field.
+| Input | Expected |
+|---|---|
+| `"Masayoshi Soken"` | `"latin"` |
+| `"祖堅正慶"` | `"cjk"` |
+| `"마마무"` | `"hangul"` |
+| `"Земфира"` | `"cyrillic"` |
+| `"!!!"` | `"unknown"` |
+
+### `test_fingerprint.py` — `_preferred_script`
+
+| Input | Expected |
+|---|---|
+| `"en"` | `"latin"` |
+| `"en-GB"` | `"latin"` |
+| `"ja"` | `"cjk"` |
+| `"zh-Hans"` | `"cjk"` |
+| `"ko"` | `"hangul"` |
+| `"ru"` | `"cyrillic"` |
+
+### `test_fingerprint.py` — `identify_audio` integration
+
+- **`langs` takes priority**: fixture with `langs` match on title; assert localized title returned without script scan.
+- **Script scan for artist**: fixture with two `music[]` entries — `[0]` has Japanese artist, `[1]` has English artist; preferred language `en`; assert English artist returned.
+- **Script scan fallback**: fixture where no entry matches preferred script; assert `music[0]` artist returned.
+- **Script scan + `langs` together**: fixture where title has a `langs` match but artist requires script scan; assert both resolved correctly.
 
 ### `test_config.py` — `get_acrcloud_language`
 
@@ -104,3 +173,4 @@ Extend the existing success fixture to include `langs` on title, artist, and alb
 - Settings UI control for language preference.
 - Language preference for the `streaming_links` / `external_metadata` payload (passed through verbatim).
 - Validation or enumeration of supported ACRCloud language codes.
+- Script detection for Arabic, Hebrew, Devanagari, or other scripts beyond Latin, CJK, Hangul, and Cyrillic.

--- a/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
+++ b/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
@@ -44,7 +44,7 @@ In practice, `langs` on artist/album is less common; the more frequent case is m
 1. Read `[acrcloud] language` from INI. If non-empty, return it.
 2. Lazy-import `winreg` (startup.py pattern — Windows-only module).
 3. Read `HKCU\Control Panel\International\LocaleName`.
-4. Return the registry value, or `"en"` on any failure.
+4. Return the registry value, or `"en"` if importing/reading the registry raises `ImportError` or `OSError`, or if the value is not a non-empty string.
 
 ### `fingerprint._pick_lang(primary: str, langs: list[dict], preferred: str) -> tuple[str, bool]`
 
@@ -99,9 +99,11 @@ Call `config.get_acrcloud_language()` and `_preferred_script()` once per invocat
 For each of title, artist names, and album name — two-pass selection:
 
 1. **`langs` pass**: apply `_pick_lang` to the `music[0]` field + its `langs` array, capturing the `(value, matched)` tuple.
-2. **Script pass**: only if `matched` is False *and* the result's dominant script does not match the preferred script, use `_pick_field` to scan all `music[]` entries for one in the preferred script.
+2. **Script pass**: only if no `langs` match was found *and* the result's dominant script does not match the preferred script, use `_pick_field` to scan all `music[]` entries for one in the preferred script.
 
 The `langs` pass takes priority — if it finds a match, the script scan is skipped for that field.
+
+**Artist field nuance:** `music[0].artists[]` is a list, so `_pick_lang` runs per-artist and the joined string is built from the per-artist results. The script-scan fallback runs only if **none** of the artists had a `langs` match — using "any matched" rather than "all matched" preserves localized artist names even when other artists in the list lack a `langs` array. Falsy artist names are filtered before joining to avoid stray separators.
 
 ### `euterpium.ini` — bundled default
 
@@ -161,6 +163,9 @@ Add a commented-out key to the `[acrcloud]` section:
 - **Script scan for artist**: fixture with two `music[]` entries — `[0]` has Japanese artist, `[1]` has English artist; preferred language `en`; assert English artist returned.
 - **Script scan fallback**: fixture where no entry matches preferred script; assert `music[0]` artist returned.
 - **Script scan + `langs` together**: fixture where title has a `langs` match but artist requires script scan; assert both resolved correctly.
+- **`langs` match outranks script mismatch**: fixture where the `langs` entry is labeled `en` but the localized name is in CJK; assert the langs match is returned and the script-scan pass is skipped.
+- **Falsy artist names are filtered**: fixture with `[{}, {"name": "Real Artist"}, {"name": ""}]`; assert no stray separators in the joined output.
+- **Partial artist langs match preserved**: fixture with one langs-matched artist and one without; assert the localized artist name is preserved (the script-scan must not run when *any* artist matched via langs).
 
 ### `test_config.py` — `get_acrcloud_language`
 
@@ -169,6 +174,7 @@ Add a commented-out key to the `[acrcloud]` section:
 | INI has explicit value | Returns INI value (no registry read) |
 | INI empty, registry returns `en-GB` | Returns `en-GB` |
 | INI empty, registry raises `OSError` | Returns `"en"` |
+| INI empty, registry returns non-string value | Returns `"en"` |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
+++ b/docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md
@@ -46,14 +46,16 @@ In practice, `langs` on artist/album is less common; the more frequent case is m
 3. Read `HKCU\Control Panel\International\LocaleName`.
 4. Return the registry value, or `"en"` on any failure.
 
-### `fingerprint._pick_lang(primary: str, langs: list[dict], preferred: str) -> str`
+### `fingerprint._pick_lang(primary: str, langs: list[dict], preferred: str) -> tuple[str, bool]`
 
-Selects the best available name using the `langs` array:
+Selects the best available name using the `langs` array and returns `(value, matched)`:
 
-1. Return `primary` immediately if `langs` is empty or `preferred` is empty.
+1. Return `(primary, False)` immediately if `langs` is empty or `preferred` is empty.
 2. Try exact match: find entry where `code == preferred`.
 3. Progressively strip the trailing subtag and retry: `en-GB` → `en`, `zh-Hans-CN` → `zh-Hans` → `zh`.
-4. Return the matched `name`, or `primary` if nothing matched.
+4. Return `(matched name, True)` when a `langs` entry matches, or `(primary, False)` if nothing matched.
+
+The `matched` flag indicates whether the selected value came from a `langs` entry rather than the primary field, so callers can preserve langs-pass priority and skip script scanning when a `langs` match was found (even if the localized name happens to be in a different script from the user's preference).
 
 ### `fingerprint._dominant_script(text: str) -> str`
 
@@ -96,8 +98,8 @@ Call `config.get_acrcloud_language()` and `_preferred_script()` once per invocat
 
 For each of title, artist names, and album name — two-pass selection:
 
-1. **`langs` pass**: apply `_pick_lang` to the `music[0]` field + its `langs` array.
-2. **Script pass**: if the result's dominant script does not match the preferred script, use `_pick_field` to scan all `music[]` entries for one in the preferred script.
+1. **`langs` pass**: apply `_pick_lang` to the `music[0]` field + its `langs` array, capturing the `(value, matched)` tuple.
+2. **Script pass**: only if `matched` is False *and* the result's dominant script does not match the preferred script, use `_pick_field` to scan all `music[]` entries for one in the preferred script.
 
 The `langs` pass takes priority — if it finds a match, the script scan is skipped for that field.
 


### PR DESCRIPTION
## Summary

Returns ACRCloud track title, artist, and album names in the user's preferred language, auto-detected from the Windows locale with an INI override.

Two-mechanism selection layered in `identify_audio()`:
1. **`langs` pass** — picks the localized name from a field's `langs` array using BCP-47 prefix matching (`zh-Hans-CN` → `zh-Hans` → `zh`).
2. **Script-scan pass** — when `langs` doesn't help, scans all `music[]` entries to find one whose primary fields are in the preferred Unicode script (Latin, CJK, Hangul, or Cyrillic).

Language preference is read fresh per call: `[acrcloud] language` in `euterpium.ini` → Windows registry `HKCU\Control Panel\International\LocaleName` → `"en"` fallback.

## Changes

- New `config.get_acrcloud_language()` with lazy `winreg` import (Windows-only)
- New private helpers in `fingerprint.py`: `_dominant_script`, `_preferred_script`, `_pick_lang`, `_pick_field`
- Refactored `identify_audio()` to apply the two-pass selection for title/artist/album
- Documented `language` key in bundled `euterpium.ini`

## Test plan

- [x] 332/332 tests pass (added 30 new tests across `test_config.py` and `test_fingerprint.py`)
- [x] `configured_credentials` fixture patches `get_acrcloud_language` → integration tests are locale-independent
- [x] Edge cases covered: missing `name` keys in `langs` entries, empty `langs` arrays, no-match fallback to `music[0]`, non-Windows registry failure → `"en"`
- [ ] Smoke test on Windows with a real ACRCloud response containing multiple `music[]` entries (e.g. FFXIV OST tracks with both `祖堅正慶` and `Masayoshi Soken` artist entries)

## Spec & Plan

- Spec: \`docs/superpowers/specs/2026-04-26-acrcloud-language-preference-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-26-acrcloud-language-preference.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)