### PR TITLE
⚙️ Fix dependabot make-release workflow to merge via PR

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -71,23 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Merge dependabot-updates into main
-        run: |
-          git fetch origin dependabot-updates
-          git merge origin/dependabot-updates --no-ff -m "Merge dependabot updates"
-          git push origin main
+      - name: Merge dependabot-updates PR into main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr merge dependabot-updates --merge --yes
 
   create-release-tag:
     needs: [check-for-updates, merge-dependabot]


### PR DESCRIPTION
## Summary
- `merge-dependabot` job was doing `git push origin main` directly, which is blocked by the "Protect Main" ruleset requiring changes via pull request
- Replaced with `gh pr merge dependabot-updates --merge` to merge the PR created by the rebase workflow
- Added `pull-requests: write` permission; removed the now-unnecessary checkout and git config steps

## Test plan
- [ ] Trigger the rebase workflow manually to verify it pushes and creates a PR
- [ ] Trigger the make-release workflow manually (with `merge_dependabot: true`) to verify it merges the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)