### PR TITLE
⚙️ Remove invalid --yes flag from gh pr merge

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh pr merge dependabot-updates --merge --yes
+        run: gh pr merge dependabot-updates --merge
 
   create-release-tag:
     needs: [check-for-updates, merge-dependabot]


### PR DESCRIPTION
## Summary
- `--yes` is not a valid flag for `gh pr merge` — incorrectly suggested by Copilot review
- `--merge` alone is sufficient to make the command non-interactive

Fixes the failure introduced in #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)