### PR TITLE
⚙️ Fix dependabot make-release workflow to merge via PR

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -78,7 +78,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh pr merge dependabot-updates --merge
+        run: |
+          gh pr ready dependabot-updates
+          gh pr merge dependabot-updates --merge
 
   create-release-tag:
     needs: [check-for-updates, merge-dependabot]


### PR DESCRIPTION
Direct push to main is blocked by branch protection rules requiring changes via pull request. Merge the PR created by the rebase workflow instead.