### PR TITLE
⚙️ Fix dependabot make-release workflow

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: read
 
     steps:
       - name: Merge dependabot-updates PR into main

--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -80,6 +80,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           gh pr ready dependabot-updates
+          gh pr checks dependabot-updates --watch --fail-fast
           gh pr merge dependabot-updates --merge
 
   create-release-tag:

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -2,7 +2,7 @@ name: "[Tests] Playnite Plugin Build"
 
 on:
   push:
-    branches: [main]
+    branches: [main, dependabot-updates]
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: "[Tests] Acceptance Testing"
 
 on:
   push:
-    branches: [main]
+    branches: [main, dependabot-updates]
   pull_request:
 
 permissions: read-all


### PR DESCRIPTION
## Summary
- Remove invalid `--yes` flag from `gh pr merge` (not a valid flag — `--merge` is sufficient)
- Add `gh pr ready` before merge to handle draft PRs created by the rebase workflow
- Add `gh pr checks --watch --fail-fast` to wait for required status checks before merging
- Add `dependabot-updates` to push triggers on both test workflows — PRs created by `GITHUB_TOKEN` don't trigger `pull_request` workflow runs, so tests must be triggered by the push to the branch instead

Fixes the chain of failures in the make-release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)